### PR TITLE
Merge fix/windows-azdevops-worktree-delete into master

### DIFF
--- a/src/main/azure-devops.ts
+++ b/src/main/azure-devops.ts
@@ -1,5 +1,7 @@
 import { spawn, execFile } from 'child_process'
 import { promisify } from 'util'
+import { existsSync } from 'fs'
+import * as path from 'path'
 import { AzureDevOpsPullRequest, SshConfig, WslConfig } from '../shared/types'
 import { augmentWindowsPath, winQuote } from './driver/runner'
 import { sshExec } from './ssh'
@@ -29,6 +31,12 @@ interface SpawnResult {
   stdout: string
   stderr: string
   code: number | null
+}
+
+interface LocalCommand {
+  cmd: string
+  args: string[]
+  shell: boolean
 }
 
 function shortRef(ref: string | undefined): string {
@@ -215,19 +223,22 @@ function parseAzureRemote(remoteUrl: string): AzureRepoContext | null {
 }
 
 async function runLocal(cmd: string, args: string[], cwd: string): Promise<SpawnResult> {
+  const command = await resolveLocalCommand(cmd, args)
+
   return new Promise((resolve) => {
     const isWindows = process.platform === 'win32'
-    const proc = isWindows
-      ? spawn([cmd, ...args.map(winQuote)].join(' '), [], {
+    const proc = isWindows && command.shell
+      ? spawn([command.cmd, ...command.args.map(winQuote)].join(' '), [], {
         cwd,
         // On Windows, global CLIs are often .cmd shims and need shell resolution.
         shell: true,
         env: augmentWindowsPath(),
         stdio: ['ignore', 'pipe', 'pipe'],
       })
-      : spawn(cmd, args, {
+      : spawn(command.cmd, command.args, {
         cwd,
         shell: false,
+        env: process.platform === 'win32' ? augmentWindowsPath() : process.env,
         stdio: ['ignore', 'pipe', 'pipe'],
       })
 
@@ -245,6 +256,38 @@ async function runLocal(cmd: string, args: string[], cwd: string): Promise<Spawn
       resolve({ stdout: '', stderr: err.message, code: null })
     })
   })
+}
+
+async function resolveLocalCommand(cmd: string, args: string[]): Promise<LocalCommand> {
+  if (process.platform !== 'win32') return { cmd, args, shell: false }
+
+  if (cmd !== 'azdevops') return { cmd, args, shell: true }
+
+  const direct = await resolveWindowsAzDevOpsNodeCommand(args)
+  if (direct) return direct
+
+  return { cmd, args, shell: true }
+}
+
+async function resolveWindowsAzDevOpsNodeCommand(args: string[]): Promise<LocalCommand | null> {
+  try {
+    const { stdout } = await execFileAsync('where.exe', ['azdevops.cmd'], { env: augmentWindowsPath() })
+    const cmdPath = stdout.split(/\r?\n/).map((line) => line.trim()).find(Boolean)
+    if (!cmdPath) return null
+
+    const baseDir = path.dirname(cmdPath)
+    const scriptPath = path.join(baseDir, 'node_modules', '@billpeet', 'azdevops-cli', 'bin', 'azdevops.js')
+    if (!existsSync(scriptPath)) return null
+
+    const adjacentNode = path.join(baseDir, 'node.exe')
+    return {
+      cmd: existsSync(adjacentNode) ? adjacentNode : 'node',
+      args: [scriptPath, ...args],
+      shell: false,
+    }
+  } catch {
+    return null
+  }
 }
 
 async function git(repoPath: string, args: string[], ssh?: SshConfig | null, wsl?: WslConfig | null): Promise<string> {
@@ -441,11 +484,7 @@ export async function createPullRequest(
   }
 
   if (payload.description?.trim()) {
-    // The azdevops CLI treats each --description value as a separate line. Passing one
-    // multi-line value gets truncated at the first newline on Windows (cmd.exe shell), so
-    // split into per-line args — no individual arg contains a newline.
-    const lines = payload.description.trim().replace(/\r\n/g, '\n').split('\n')
-    args.push('--description', ...lines)
+    args.push('--description', payload.description.trim().replace(/\r\n/g, '\n'))
   }
 
   const output = await runAzDevOps(repoPath, args, ssh, wsl)

--- a/src/main/driver/runner/utils.ts
+++ b/src/main/driver/runner/utils.ts
@@ -16,7 +16,7 @@ export function shellEscape(s: string): string {
  * so arguments with spaces must be explicitly double-quoted.
  */
 export function winQuote(s: string): string {
-  if (!/[ \t"&|<>^]/.test(s)) return s
+  if (!/[ \t\r\n"&|<>^]/.test(s)) return s
   return '"' + s.replace(/"/g, '\\"') + '"'
 }
 

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -76,6 +76,7 @@ export default function Sidebar() {
 
   const locationsByProject = useLocationStore((s) => s.byProject)
   const poolsByProject = useLocationStore((s) => s.poolsByProject)
+  const deletingWorktreesByProject = useLocationStore((s) => s.deletingWorktreesByProject)
   const fetchLocations = useLocationStore((s) => s.fetch)
   const fetchPools = useLocationStore((s) => s.fetchPools)
   const checkoutLocation = useLocationStore((s) => s.checkout)
@@ -459,6 +460,7 @@ export default function Sidebar() {
       unreadByThread={unreadByThread}
       locationsByProject={locationsByProject}
       poolsByProject={poolsByProject}
+      deletingWorktreesByProject={deletingWorktreesByProject}
       collapsedLocationIds={collapsedLocationIds}
       expandedAvailablePools={expandedAvailablePools}
       pathExistsByLocation={pathExistsByLocation}

--- a/src/renderer/src/components/sidebar/ExpandedSidebar.tsx
+++ b/src/renderer/src/components/sidebar/ExpandedSidebar.tsx
@@ -24,6 +24,7 @@ interface ExpandedSidebarProps {
   unreadByThread: Record<string, boolean | undefined>
   locationsByProject: Record<string, RepoLocation[] | undefined>
   poolsByProject: Record<string, LocationPool[] | undefined>
+  deletingWorktreesByProject: Record<string, number | undefined>
   collapsedLocationIds: Set<string>
   expandedAvailablePools: Set<string>
   pathExistsByLocation: Record<string, boolean>
@@ -71,6 +72,7 @@ export default function ExpandedSidebar({
   unreadByThread,
   locationsByProject,
   poolsByProject,
+  deletingWorktreesByProject,
   collapsedLocationIds,
   expandedAvailablePools,
   pathExistsByLocation,
@@ -228,6 +230,7 @@ export default function ExpandedSidebar({
           const archivedPageCount = Math.ceil(projectArchivedCount / 10)
           const locations = locationsByProject[project.id] ?? EMPTY_LOCATIONS
           const pools = poolsByProject[project.id] ?? EMPTY_POOLS
+          const deletingWorktreeCount = deletingWorktreesByProject[project.id] ?? 0
           const runningThreads = projectThreads.filter((thread) => statusMap[thread.id] === 'running' || statusMap[thread.id] === 'stopping')
           const unreadThreads = projectThreads.filter((thread) => (unreadByThread[thread.id] ?? !!thread.unread) && statusMap[thread.id] !== 'running' && statusMap[thread.id] !== 'stopping')
           const unreadCount = unreadThreads.length
@@ -476,6 +479,15 @@ export default function ExpandedSidebar({
                         />
                       ))}
                     </>
+                  )}
+
+                  {deletingWorktreeCount > 0 && (
+                    <div className="flex items-center gap-2 pl-6 pr-4 py-1 text-[10px]" style={{ color: 'var(--color-text-muted)' }}>
+                      <div className="status-spinner h-2.5 w-2.5 flex-shrink-0" />
+                      <span className="truncate">
+                        Deleting {deletingWorktreeCount} worktree{deletingWorktreeCount === 1 ? '' : 's'}...
+                      </span>
+                    </div>
                   )}
 
                   {projectThreads

--- a/src/renderer/src/stores/locations.ts
+++ b/src/renderer/src/stores/locations.ts
@@ -5,6 +5,7 @@ import { useThreadStore } from './threads'
 interface LocationStore {
   byProject: Record<string, RepoLocation[]>
   poolsByProject: Record<string, LocationPool[]>
+  deletingWorktreesByProject: Record<string, number>
   fetch: (projectId: string) => Promise<void>
   fetchPools: (projectId: string) => Promise<void>
   createPool: (projectId: string, name: string) => Promise<LocationPool>
@@ -22,6 +23,7 @@ interface LocationStore {
 export const useLocationStore = create<LocationStore>((set) => ({
   byProject: {},
   poolsByProject: {},
+  deletingWorktreesByProject: {},
 
   fetch: async (projectId) => {
     const locations = await window.api.invoke('locations:list', projectId)
@@ -124,52 +126,84 @@ export const useLocationStore = create<LocationStore>((set) => ({
   removeWorktree: async (id, projectId) => {
     const activeThreads = useThreadStore.getState().byProject[projectId] ?? []
     const worktreeThreadIds = new Set(activeThreads.filter((thread) => thread.location_id === id).map((thread) => thread.id))
-    await window.api.invoke('locations:removeWorktree', id)
-    if (worktreeThreadIds.size > 0) {
-      useThreadStore.setState((s) => {
-        const removedThreads = (s.byProject[projectId] ?? []).filter((thread) => worktreeThreadIds.has(thread.id))
-        const nextStatusMap = { ...s.statusMap }
-        const nextUnreadByThread = { ...s.unreadByThread }
-        const nextQueuedByThread = { ...s.queuedMessageByThread }
-        const nextPlanModeByThread = { ...s.planModeByThread }
-        const nextFastModeByThread = { ...s.fastModeByThread }
-        const nextRunStartedAtByThread = { ...s.runStartedAtByThread }
-        const nextPidByThread = { ...s.pidByThread }
-        for (const threadId of worktreeThreadIds) {
-          delete nextStatusMap[threadId]
-          delete nextUnreadByThread[threadId]
-          delete nextQueuedByThread[threadId]
-          delete nextPlanModeByThread[threadId]
-          delete nextFastModeByThread[threadId]
-          delete nextRunStartedAtByThread[threadId]
-          delete nextPidByThread[threadId]
-        }
-        return {
-          byProject: {
-            ...s.byProject,
-            [projectId]: (s.byProject[projectId] ?? []).filter((thread) => !worktreeThreadIds.has(thread.id))
-          },
-          archivedCountByProject: {
-            ...s.archivedCountByProject,
-            [projectId]: (s.archivedCountByProject[projectId] ?? 0) + removedThreads.filter((thread) => thread.has_messages).length
-          },
-          selectedThreadId: s.selectedThreadId && worktreeThreadIds.has(s.selectedThreadId) ? null : s.selectedThreadId,
-          statusMap: nextStatusMap,
-          unreadByThread: nextUnreadByThread,
-          queuedMessageByThread: nextQueuedByThread,
-          planModeByThread: nextPlanModeByThread,
-          fastModeByThread: nextFastModeByThread,
-          runStartedAtByThread: nextRunStartedAtByThread,
-          pidByThread: nextPidByThread,
-        }
-      })
-    }
+    const locationsSnapshot = (useLocationStore.getState().byProject[projectId] ?? []).slice()
+    const threadSnapshot = useThreadStore.getState()
+
+    useThreadStore.setState((s) => {
+      const removedThreads = (s.byProject[projectId] ?? []).filter((thread) => worktreeThreadIds.has(thread.id))
+      const nextStatusMap = { ...s.statusMap }
+      const nextUnreadByThread = { ...s.unreadByThread }
+      const nextQueuedByThread = { ...s.queuedMessageByThread }
+      const nextPlanModeByThread = { ...s.planModeByThread }
+      const nextFastModeByThread = { ...s.fastModeByThread }
+      const nextRunStartedAtByThread = { ...s.runStartedAtByThread }
+      const nextPidByThread = { ...s.pidByThread }
+      for (const threadId of worktreeThreadIds) {
+        delete nextStatusMap[threadId]
+        delete nextUnreadByThread[threadId]
+        delete nextQueuedByThread[threadId]
+        delete nextPlanModeByThread[threadId]
+        delete nextFastModeByThread[threadId]
+        delete nextRunStartedAtByThread[threadId]
+        delete nextPidByThread[threadId]
+      }
+      return {
+        byProject: {
+          ...s.byProject,
+          [projectId]: (s.byProject[projectId] ?? []).filter((thread) => !worktreeThreadIds.has(thread.id))
+        },
+        archivedCountByProject: {
+          ...s.archivedCountByProject,
+          [projectId]: (s.archivedCountByProject[projectId] ?? 0) + removedThreads.filter((thread) => thread.has_messages).length
+        },
+        selectedThreadId: s.selectedThreadId && worktreeThreadIds.has(s.selectedThreadId) ? null : s.selectedThreadId,
+        statusMap: nextStatusMap,
+        unreadByThread: nextUnreadByThread,
+        queuedMessageByThread: nextQueuedByThread,
+        planModeByThread: nextPlanModeByThread,
+        fastModeByThread: nextFastModeByThread,
+        runStartedAtByThread: nextRunStartedAtByThread,
+        pidByThread: nextPidByThread,
+      }
+    })
     set((s) => ({
+      deletingWorktreesByProject: {
+        ...s.deletingWorktreesByProject,
+        [projectId]: (s.deletingWorktreesByProject[projectId] ?? 0) + 1,
+      },
       byProject: {
         ...s.byProject,
         [projectId]: (s.byProject[projectId] ?? []).filter((l) => l.id !== id)
       }
     }))
+    try {
+      await window.api.invoke('locations:removeWorktree', id)
+    } catch (error) {
+      useThreadStore.setState({
+        byProject: threadSnapshot.byProject,
+        archivedCountByProject: threadSnapshot.archivedCountByProject,
+        selectedThreadId: threadSnapshot.selectedThreadId,
+        statusMap: threadSnapshot.statusMap,
+        unreadByThread: threadSnapshot.unreadByThread,
+        queuedMessageByThread: threadSnapshot.queuedMessageByThread,
+        planModeByThread: threadSnapshot.planModeByThread,
+        fastModeByThread: threadSnapshot.fastModeByThread,
+        runStartedAtByThread: threadSnapshot.runStartedAtByThread,
+        pidByThread: threadSnapshot.pidByThread,
+      })
+      set((s) => ({
+        byProject: { ...s.byProject, [projectId]: locationsSnapshot }
+      }))
+      throw error
+    } finally {
+      set((s) => {
+        const currentCount = s.deletingWorktreesByProject[projectId] ?? 0
+        const nextDeleting = { ...s.deletingWorktreesByProject }
+        if (currentCount <= 1) delete nextDeleting[projectId]
+        else nextDeleting[projectId] = currentCount - 1
+        return { deletingWorktreesByProject: nextDeleting }
+      })
+    }
   },
 
   checkout: async (id, projectId) => {


### PR DESCRIPTION
## Summary

- Update Azure DevOps PR creation on Windows to resolve the CLI command more reliably and pass the full description as a single argument
- Broaden Windows quoting to treat newline characters as requiring quotes, avoiding command-line parsing issues
- Add location-store tracking for in-flight worktree deletions so the sidebar can show per-project deletion progress
- Preserve and restore thread/location state around failed worktree removals instead of leaving the UI in a partially updated state
- Render a sidebar status row while worktrees are being deleted

## Notes

- The worktree removal flow now performs optimistic UI updates and then rolls them back on failure, so the progress indicator and restored state depend on the backend operation succeeding or throwing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when running local commands on Windows.
  * Fixed multi-line pull request descriptions so they are submitted consistently.
  * Worktree removal now updates the app more safely and restores state if deletion fails.

* **New Features**
  * Added a visible “deleting worktree” status indicator in the sidebar when removals are in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->