### PR TITLE
Fix Windows command quoting for trailing backslashes and embedded quotes

### DIFF
--- a/src/main/driver/__tests__/runner-utils.test.ts
+++ b/src/main/driver/__tests__/runner-utils.test.ts
@@ -60,6 +60,14 @@ describe('winQuote', () => {
     expect(winQuote('say "hi"')).toBe('"say \\"hi\\""')
   })
 
+  it('doubles trailing backslashes before the closing quote', () => {
+    expect(winQuote('C:\\Program Files\\App\\')).toBe('"C:\\Program Files\\App\\\\"')
+  })
+
+  it('doubles backslashes before embedded double quotes', () => {
+    expect(winQuote('C:\\path\\\\"value"')).toBe('"C:\\path\\\\\\\\\\"value\\""')
+  })
+
   it('wraps strings containing & | < > ^ cmd special chars', () => {
     expect(winQuote('a&b')).toBe('"a&b"')
     expect(winQuote('a|b')).toBe('"a|b"')

--- a/src/main/driver/runner/utils.ts
+++ b/src/main/driver/runner/utils.ts
@@ -17,7 +17,7 @@ export function shellEscape(s: string): string {
  */
 export function winQuote(s: string): string {
   if (!/[ \t\r\n"&|<>^]/.test(s)) return s
-  return '"' + s.replace(/"/g, '\\"') + '"'
+  return '"' + s.replace(/(\\*)"/g, '$1$1\\"').replace(/\\+$/g, '$&$&') + '"'
 }
 
 function getWindowsPathKey(env: NodeJS.ProcessEnv): 'PATH' | 'Path' {


### PR DESCRIPTION
## Summary

- Update `winQuote` to correctly escape backslashes before embedded double quotes.
- Double trailing backslashes so quoted Windows paths remain valid when they end with `\`.
- Add regression tests covering trailing backslashes and backslashes before quotes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows command-line quoting so arguments with embedded quotes and trailing backslashes are escaped correctly.
  * Fixed cases where quoted arguments could lose or misplace backslashes at the end or before double quotes.

* **Tests**
  * Added coverage for Windows-style escaping scenarios to verify the updated quoting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->