### PR TITLE
Fix release CI tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
+      - name: Install test runtime binaries
+        run: node node_modules/electron/install.js
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -11,7 +11,7 @@
     "start": "electron .",
     "start:prod": "pnpm run build && cross-env NODE_ENV=production electron .",
     "typecheck": "tsc --build --noEmit",
-    "test": "vitest run",
+    "test": "pnpm --dir ../../node_modules/better-sqlite3 exec prebuild-install && vitest run",
     "dist": "pnpm run build && electron-builder --win",
     "dist:publish": "pnpm run build && electron-builder --win --publish always"
   },

--- a/apps/desktop/src/main/driver/codex.ts
+++ b/apps/desktop/src/main/driver/codex.ts
@@ -1389,13 +1389,14 @@ function sanitizeEnv(env: NodeJS.ProcessEnv): Record<string, string> {
 export function buildCodexEnvironment(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
   const nextEnv = process.platform === 'win32' ? augmentWindowsPath(env) : { ...env }
   const homeDir = nextEnv.HOME ?? nextEnv.USERPROFILE ?? homedir()
+  const homePath = nextEnv.USERPROFILE && homeDir === nextEnv.USERPROFILE ? path.win32 : path
 
   if (!nextEnv.HOME && homeDir) nextEnv.HOME = homeDir
   if (process.platform === 'win32' && !nextEnv.USERPROFILE && homeDir) {
     nextEnv.USERPROFILE = homeDir
   }
   if (!nextEnv.CODEX_HOME && homeDir) {
-    nextEnv.CODEX_HOME = path.join(homeDir, '.codex')
+    nextEnv.CODEX_HOME = homePath.join(homeDir, '.codex')
   }
 
   return sanitizeEnv(nextEnv)


### PR DESCRIPTION
## Summary

- install Electron's runtime binary in the Linux quality job
- install the host-Node `better-sqlite3` prebuilt before running Vitest
- preserve Windows path separators when deriving `CODEX_HOME` from `USERPROFILE`

## Root cause

The quality job installs dependencies with lifecycle scripts disabled. That leaves Electron without its runtime binary and `better-sqlite3` without a Node-compatible native binding. The Windows environment test also used the runner's native path implementation, so Linux produced a mixed-separator Windows path.

## Impact

Release quality checks can run the Electron and migration tests on Ubuntu while Windows application packaging continues to install Electron-ABI native binaries through the existing postinstall flow.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (241 passed, 15 skipped)
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when locating the Codex configuration directory on Windows and other platforms.
  * Improved desktop test setup by automatically preparing required native and runtime components before tests run.

* **Quality Improvements**
  * Release validation now prepares Electron runtime components before type checking, linting, and automated tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->