### PR TITLE
Unify message transcript folding

### DIFF
--- a/apps/desktop/src/main/__tests__/message-compaction.test.ts
+++ b/apps/desktop/src/main/__tests__/message-compaction.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { compactStreamingMessages } from '../db/queries'
-import type { MessageRow } from '../db/models'
+import { foldMessages, type Message } from '@polycode/shared'
 
-function thinkingRow(id: string, content: string, itemId: string, summaryIndex: number): MessageRow {
+function thinkingMessage(id: string, content: string, itemId: string, summaryIndex: number): Message {
   return {
     id,
     thread_id: 'thread-1',
@@ -21,13 +20,63 @@ function thinkingRow(id: string, content: string, itemId: string, summaryIndex: 
 }
 
 describe('message compaction', () => {
+  it('keeps consecutive assistant messages from different agent scopes separate', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        thread_id: 'thread-1',
+        session_id: 'session-1',
+        role: 'assistant',
+        content: 'Main agent',
+        metadata: null,
+        created_at: '2026-07-13T00:00:01.000Z',
+      },
+      {
+        id: '2',
+        thread_id: 'thread-1',
+        session_id: 'session-1',
+        role: 'assistant',
+        content: 'Sub-agent',
+        metadata: JSON.stringify({ agent_task_id: 'task-1' }),
+        created_at: '2026-07-13T00:00:02.000Z',
+      },
+    ]
+
+    expect(foldMessages(messages)).toEqual(messages)
+  })
+
+  it('keeps claude task lifecycle messages separate', () => {
+    const messages: Message[] = [
+      {
+        id: '1',
+        thread_id: 'thread-1',
+        session_id: 'session-1',
+        role: 'assistant',
+        content: 'Subagent started',
+        metadata: JSON.stringify({ type: 'thinking', source: 'claude_task', status: 'running' }),
+        created_at: '2026-07-13T00:00:01.000Z',
+      },
+      {
+        id: '2',
+        thread_id: 'thread-1',
+        session_id: 'session-1',
+        role: 'assistant',
+        content: 'Subagent completed',
+        metadata: JSON.stringify({ type: 'thinking', source: 'claude_task', status: 'completed' }),
+        created_at: '2026-07-13T00:00:02.000Z',
+      },
+    ]
+
+    expect(foldMessages(messages)).toEqual(messages)
+  })
+
   it('cleans persisted Codex summary markers and separates distinct summary parts', () => {
-    const compacted = compactStreamingMessages([
-      thinkingRow('1', 'Reasoning summary updated.', 'reason-1', 0),
-      thinkingRow('2', '**Planning the change**', 'reason-1', 0),
-      thinkingRow('3', ' safely', 'reason-1', 0),
-      thinkingRow('4', '**Running verification**', 'reason-1', 1),
-      thinkingRow('5', '**Reporting results**', 'reason-2', 0),
+    const compacted = foldMessages([
+      thinkingMessage('1', 'Reasoning summary updated.', 'reason-1', 0),
+      thinkingMessage('2', '**Planning the change**', 'reason-1', 0),
+      thinkingMessage('3', ' safely', 'reason-1', 0),
+      thinkingMessage('4', '**Running verification**', 'reason-1', 1),
+      thinkingMessage('5', '**Reporting results**', 'reason-2', 0),
     ])
 
     expect(compacted).toHaveLength(1)

--- a/apps/desktop/src/main/db/queries.ts
+++ b/apps/desktop/src/main/db/queries.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid'
 import { getDb } from './index'
 import { ProjectRow, RepoLocationRow, ThreadRow, MessageRow, SessionRow, ProjectCommandRow, YouTrackServerRow, SlashCommandRow, LocationPoolRow } from './models'
+import { foldMessages } from '@polycode/shared'
 import { CodexPersonality, CodexReasoningSummary, Project, Thread, Message, Session, RepoLocation, SshConfig, WslConfig, ConnectionType, Provider, PermissionMode, ReasoningLevel, getModelsForProvider, getDefaultModelForProvider, ProjectCommand, YouTrackServer, SlashCommand, LocationPool } from '../../shared/types'
 
 // ── Projects ──────────────────────────────────────────────────────────────────
@@ -839,113 +840,11 @@ export function getOrCreateActiveSession(threadId: string): Session {
 
 // ── Messages ──────────────────────────────────────────────────────────────────
 
-function parseMessageMetadata(metadata: string | null): Record<string, unknown> | null {
-  if (!metadata) return null
-  try {
-    return JSON.parse(metadata) as Record<string, unknown>
-  } catch {
-    return null
-  }
-}
-
-const LEGACY_CODEX_REASONING_SUMMARY_MARKER = 'Reasoning summary updated.'
-
-function isCodexReasoningSummary(metadata: Record<string, unknown> | null): boolean {
-  return metadata?.source === 'codex_reasoning_summary'
-}
-
-function isSameCodexReasoningSummaryPart(
-  previous: Record<string, unknown> | null,
-  current: Record<string, unknown> | null,
-): boolean {
-  return previous?.item_id === current?.item_id && previous?.summary_index === current?.summary_index
-}
-
-export function compactStreamingMessages(messages: MessageRow[]): Message[] {
-  const compacted: MessageRow[] = []
-
-  for (const message of messages) {
-    const currentMetadata = parseMessageMetadata(message.metadata)
-    // Clean up structural markers persisted by older Polycode versions.
-    if (
-      message.content === LEGACY_CODEX_REASONING_SUMMARY_MARKER &&
-      isCodexReasoningSummary(currentMetadata)
-    ) {
-      continue
-    }
-
-    const previous = compacted[compacted.length - 1]
-    if (!previous || previous.role !== message.role) {
-      compacted.push({ ...message })
-      continue
-    }
-
-    const previousMetadata = parseMessageMetadata(previous.metadata)
-    const previousType = previousMetadata?.type
-    const currentType = currentMetadata?.type
-
-    if (!previousType && !currentType && message.role === 'assistant') {
-      previous.content += message.content
-      previous.created_at = message.created_at
-      continue
-    }
-
-    if (previousType === 'thinking' && currentType === 'thinking' && message.role === 'assistant') {
-      const isCodexSummaryPair =
-        isCodexReasoningSummary(previousMetadata) && isCodexReasoningSummary(currentMetadata)
-      const separator =
-        isCodexSummaryPair && !isSameCodexReasoningSummaryPart(previousMetadata, currentMetadata)
-          ? '\n\n'
-          : ''
-      previous.content += separator + message.content
-      if (isCodexSummaryPair) previous.metadata = message.metadata
-      previous.created_at = message.created_at
-      continue
-    }
-
-    if (previousType === 'tool_result' && currentType === 'tool_result') {
-      const previousToolUseId = typeof previousMetadata?.tool_use_id === 'string' ? previousMetadata.tool_use_id : null
-      const currentToolUseId = typeof currentMetadata?.tool_use_id === 'string' ? currentMetadata.tool_use_id : null
-      if (previousToolUseId && previousToolUseId === currentToolUseId) {
-        if (currentMetadata?.authoritative === true) {
-          previous.content = message.content
-          previous.metadata = message.metadata
-          previous.created_at = message.created_at
-          continue
-        }
-        previous.content = message.content.startsWith(previous.content)
-          ? message.content
-          : previous.content + message.content
-        previous.metadata = message.metadata
-        previous.created_at = message.created_at
-        continue
-      }
-    }
-
-    compacted.push({ ...message })
-  }
-
-  return compacted as Message[]
-}
-
-function shouldCompactMessagesForThread(threadId: string): boolean {
-  const provider = getThreadProvider(threadId)
-  return provider === 'codex' || provider === 'pi' || provider === 'cursor'
-}
-
-function shouldCompactMessagesForSession(sessionId: string): boolean {
-  const row = getDb()
-    .prepare('SELECT t.provider FROM sessions s JOIN threads t ON t.id = s.thread_id WHERE s.id = ?')
-    .get(sessionId) as { provider: string | null } | undefined
-  const provider = row?.provider ?? 'claude-code'
-  return provider === 'codex' || provider === 'pi' || provider === 'cursor'
-}
-
 export function listMessages(threadId: string): Message[] {
   const rows = getDb()
     .prepare('SELECT * FROM messages WHERE thread_id = ? ORDER BY created_at ASC')
     .all(threadId) as MessageRow[]
-  return shouldCompactMessagesForThread(threadId) ? compactStreamingMessages(rows) : rows as Message[]
+  return foldMessages(rows as Message[])
 }
 
 export function insertMessage(
@@ -978,7 +877,7 @@ export function listMessagesBySession(sessionId: string): Message[] {
   const rows = getDb()
     .prepare('SELECT * FROM messages WHERE session_id = ? ORDER BY created_at ASC')
     .all(sessionId) as MessageRow[]
-  return shouldCompactMessagesForSession(sessionId) ? compactStreamingMessages(rows) : rows as Message[]
+  return foldMessages(rows as Message[])
 }
 
 /**

--- a/apps/desktop/src/renderer/src/stores/messages.ts
+++ b/apps/desktop/src/renderer/src/stores/messages.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { appendOrMergeMessage, eventRole } from '@polycode/shared'
+import { eventRole, foldMessages } from '@polycode/shared'
 import { Message, OutputEvent } from '../types/ipc'
 
 interface MessageStore {
@@ -50,7 +50,7 @@ export const useMessageStore = create<MessageStore>((set) => ({
     set((s) => ({
       messagesByThread: {
         ...s.messagesByThread,
-        [threadId]: appendOrMergeMessage(s.messagesByThread[threadId] ?? [], msg, event)
+        [threadId]: foldMessages([...(s.messagesByThread[threadId] ?? []), msg])
       }
     }))
   },
@@ -71,7 +71,7 @@ export const useMessageStore = create<MessageStore>((set) => ({
     set((s) => ({
       messagesBySession: {
         ...s.messagesBySession,
-        [sessionId]: appendOrMergeMessage(s.messagesBySession[sessionId] ?? [], msg, event)
+        [sessionId]: foldMessages([...(s.messagesBySession[sessionId] ?? []), msg])
       }
     }))
   },

--- a/apps/mobile/src/stores/messages.ts
+++ b/apps/mobile/src/stores/messages.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import {
-  appendOrMergeMessage,
   eventRole,
+  foldMessages,
   type Message,
   type OutputEvent,
   type RateLimitInfo,
@@ -81,7 +81,7 @@ export const useMessagesStore = create<MessagesState>((set) => ({
     set((s) => ({
       messagesByThread: {
         ...s.messagesByThread,
-        [threadId]: appendOrMergeMessage(s.messagesByThread[threadId] ?? [], msg, event),
+        [threadId]: foldMessages([...(s.messagesByThread[threadId] ?? []), msg]),
       },
     }))
   },

--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -52,14 +52,17 @@ export function eventRole(event: OutputEvent): Message['role'] {
  * previous bubble. This encodes the streaming display rules shared by the
  * desktop renderer and the mobile app.
  */
-export function appendOrMergeMessage(messages: Message[], incoming: Message, event: OutputEvent): Message[] {
+function appendOrMergeMessage(messages: Message[], incoming: Message): Message[] {
+  const nextMetadata = parseMetadata(incoming.metadata)
+  const incomingType = nextMetadata?.type
+
   // Older Polycode versions turned Codex's structural summaryPartAdded
   // notification into this visible sentence. Ignore it when replayed by an
   // older remote or encountered in an in-flight stream during an upgrade.
   if (
-    event.type === 'thinking' &&
-    event.content === LEGACY_CODEX_REASONING_SUMMARY_MARKER &&
-    isCodexReasoningSummary(event.metadata ?? null)
+    incomingType === 'thinking' &&
+    incoming.content === LEGACY_CODEX_REASONING_SUMMARY_MARKER &&
+    isCodexReasoningSummary(nextMetadata)
   ) {
     return messages
   }
@@ -70,13 +73,12 @@ export function appendOrMergeMessage(messages: Message[], incoming: Message, eve
   }
 
   const previousMetadata = parseMetadata(previous.metadata)
-  const nextMetadata = event.metadata ?? null
 
   // Never merge across agent scopes: main-scope assistant text followed by
   // sub-agent assistant text (both role 'assistant') must stay separate bubbles.
   const sameScope = agentKey(previousMetadata) === agentKey(nextMetadata)
 
-  if (event.type === 'text') {
+  if (!incomingType || incomingType === 'text') {
     // User-role events (question answers, remote-client sends) are discrete
     // messages, never streaming chunks — don't merge them into the previous
     // bubble or fuse consecutive user messages together.
@@ -97,7 +99,7 @@ export function appendOrMergeMessage(messages: Message[], incoming: Message, eve
     return [...messages, incoming]
   }
 
-  if (event.type === 'thinking') {
+  if (incomingType === 'thinking') {
     const previousType = previousMetadata?.type
     // Never merge sub-agent task lifecycle bubbles (started/progress/notification): each
     // carries unique per-event metadata (status, usage) that deriveAgentMeta relies on.
@@ -127,7 +129,7 @@ export function appendOrMergeMessage(messages: Message[], incoming: Message, eve
     return [...messages, incoming]
   }
 
-  if (event.type === 'tool_result') {
+  if (incomingType === 'tool_result') {
     // Only merge into a *previous tool_result* streaming chunk for the same tool_use_id.
     // Guard on the previous type: task lifecycle bubbles (e.g. a "Subagent completed"
     // notification) carry the spawning Task/Agent tool_use_id in their metadata, so
@@ -165,4 +167,12 @@ export function appendOrMergeMessage(messages: Message[], incoming: Message, eve
   }
 
   return [...messages, incoming]
+}
+
+/**
+ * Fold persisted or streamed messages into their display form using the same
+ * merge rules in every caller.
+ */
+export function foldMessages(messages: Message[]): Message[] {
+  return messages.reduce<Message[]>(appendOrMergeMessage, [])
 }


### PR DESCRIPTION
## What changed

- add one shared `foldMessages(messages)` interface in `@polycode/shared`
- use the same fold for desktop streaming, mobile streaming, thread read-back, and session read-back
- remove the duplicate database compaction implementation and provider-specific persistence gates
- cover agent-scope separation, Claude task lifecycle messages, and legacy Codex reasoning summaries

## Why

Streaming and persisted messages used different merge implementations. The database copy lacked the agent-scope and `claude_task` lifecycle guards, so a thread could render differently after refetch and could lose terminal sub-agent metadata.

This concentrates the display rules behind one pure shared interface so live and read-back paths cannot diverge.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- focused message compaction tests: 3 passed
- full suite: 239 passed, 15 skipped; four migration tests are blocked locally by an existing `better-sqlite3` Node ABI mismatch (binary ABI 140, active Node ABI 127)
