### PR TITLE
fix: render ordinary markdown links without crashing the transcript

### DIFF
--- a/apps/desktop/src/renderer/src/components/MarkdownContent.tsx
+++ b/apps/desktop/src/renderer/src/components/MarkdownContent.tsx
@@ -6,8 +6,8 @@ import { reportPerf } from '../lib/perf'
 import {
   filePathFromMarkdownCopyTarget,
   handleMarkdownFileLinkClick,
-  markdownFilePathFromHref,
 } from '../lib/markdownFileLinks'
+import { escapeAttr, renderMarkdownLink } from '../lib/markdownLinkRenderer'
 import { useFilesStore } from '../stores/files'
 import { useUiStore } from '../stores/ui'
 
@@ -15,13 +15,6 @@ import { useUiStore } from '../stores/ui'
 marked.setOptions({
   async: false
 })
-
-function escapeAttr(str: string): string {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-}
 
 function escapeHtml(str: string): string {
   return str
@@ -31,16 +24,7 @@ function escapeHtml(str: string): string {
 }
 
 const renderer = new marked.Renderer()
-const defaultLinkRenderer = renderer.link.bind(renderer)
-renderer.link = function (token) {
-  const filePath = markdownFilePathFromHref(token.href)
-  if (!filePath) return defaultLinkRenderer(token)
-
-  const text = this.parser.parseInline(token.tokens)
-  const title = token.title ? ` title="${escapeAttr(token.title)}"` : ''
-  const encodedPath = escapeAttr(encodeURIComponent(filePath))
-  return `<span class="file-link-with-copy"><a href="#" data-file-path="${encodedPath}"${title}>${text}</a><button type="button" class="file-path-copy-btn" data-file-path="${encodedPath}" title="Copy file path" aria-label="Copy file path"><svg viewBox="0 0 16 16" aria-hidden="true"><rect x="5.5" y="5.5" width="7" height="7" rx="1"></rect><path d="M10.5 5.5V4a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v5.5a1 1 0 0 0 1 1h1.5"></path></svg></button></span>`
-}
+renderer.link = renderMarkdownLink
 
 renderer.code = function ({ text, lang }) {
   const hl = getHighlighter()

--- a/apps/desktop/src/renderer/src/lib/__tests__/markdownLinkRenderer.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/markdownLinkRenderer.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { Marked, Renderer } from 'marked'
+import { renderMarkdownLink } from '../markdownLinkRenderer'
+
+function parse(markdown: string): string {
+  const renderer = new Renderer()
+  renderer.link = renderMarkdownLink
+  const instance = new Marked({ async: false })
+  instance.use({ renderer })
+  return (instance.parse(markdown) as string).trim()
+}
+
+describe('markdown link renderer', () => {
+  // Regression: the fallback used to be captured with .bind(renderer), so it
+  // ran against a renderer marked never attached a parser to — every ordinary
+  // link threw "Cannot read properties of undefined (reading 'parseInline')"
+  // and took the whole transcript down with it.
+  it('renders an ordinary web link without throwing', () => {
+    expect(parse('see [the docs](https://example.com)')).toBe(
+      '<p>see <a href="https://example.com">the docs</a></p>'
+    )
+  })
+
+  it('keeps inline formatting inside an ordinary link', () => {
+    expect(parse('see [**bold** docs](https://example.com)')).toBe(
+      '<p>see <a href="https://example.com"><strong>bold</strong> docs</a></p>'
+    )
+  })
+
+  it('preserves the title on an ordinary link', () => {
+    expect(parse('[docs](https://example.com "Title")')).toBe(
+      '<p><a href="https://example.com" title="Title">docs</a></p>'
+    )
+  })
+
+  it('renders an autolink without throwing', () => {
+    expect(parse('visit <https://example.com>')).toBe(
+      '<p>visit <a href="https://example.com">https://example.com</a></p>'
+    )
+  })
+
+  it('gives file links preview and copy-path chrome', () => {
+    const html = parse('open [main.ts](file:///C:/tmp/main.ts)')
+    expect(html).toContain('class="file-link-with-copy"')
+    expect(html).toContain('class="file-path-copy-btn"')
+    expect(html).toContain('data-file-path="C%3A%5Ctmp%5Cmain.ts"')
+    expect(html).toContain('>main.ts</a>')
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/markdownLinkRenderer.ts
+++ b/apps/desktop/src/renderer/src/lib/markdownLinkRenderer.ts
@@ -1,0 +1,26 @@
+import { Renderer, type Tokens } from 'marked'
+import { markdownFilePathFromHref } from './markdownFileLinks'
+
+export function escapeAttr(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+// marked binds the active parser onto the renderer it invokes, so the base
+// implementation has to be called with that same `this` — a renderer captured
+// with .bind() never receives a parser and blows up on `this.parser`.
+const defaultLinkRenderer = Renderer.prototype.link
+
+// File links get preview + copy-path chrome; everything else falls through to
+// marked's stock anchor rendering.
+export function renderMarkdownLink(this: Renderer, token: Tokens.Link): string {
+  const filePath = markdownFilePathFromHref(token.href)
+  if (!filePath) return defaultLinkRenderer.call(this, token)
+
+  const text = this.parser.parseInline(token.tokens)
+  const title = token.title ? ` title="${escapeAttr(token.title)}"` : ''
+  const encodedPath = escapeAttr(encodeURIComponent(filePath))
+  return `<span class="file-link-with-copy"><a href="#" data-file-path="${encodedPath}"${title}>${text}</a><button type="button" class="file-path-copy-btn" data-file-path="${encodedPath}" title="Copy file path" aria-label="Copy file path"><svg viewBox="0 0 16 16" aria-hidden="true"><rect x="5.5" y="5.5" width="7" height="7" rx="1"></rect><path d="M10.5 5.5V4a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v5.5a1 1 0 0 0 1 1h1.5"></path></svg></button></span>`
+}


### PR DESCRIPTION
## The crash

PolyCode 0.14.0 appeared to crash on startup. It was actually a renderer crash: every **ordinary (non-file) markdown link** threw

```
TypeError: Cannot read properties of undefined (reading 'parseInline')
```

from `MarkdownContent`, which propagated up through `MessageBubble` → `MessageStream` → `ThreadView` to the app-level error boundary and replaced the entire UI with "Something went wrong. Please restart PolyCode." Since startup restores the last thread, any thread containing a plain link made the app unusable from launch — and restarting re-selected the same thread and re-crashed.

## Cause

`MarkdownContent.tsx` captured marked's stock link renderer as `renderer.link.bind(renderer)`. marked attaches the active parser to *its own internal* renderer at parse time, not to the detached `new marked.Renderer()` instance — so the bound `this` never had a `.parser`.

The file-link path worked fine (there `this` was marked's renderer, which does have a parser), so this only ever affected plain links. That asymmetry is why it got through review and shipped.

Introduced in 0f3f5af, released in 0.14.0.

## Fix

Call the base implementation with the parser-bearing `this`:

```ts
const defaultLinkRenderer = Renderer.prototype.link   // was: renderer.link.bind(renderer)
if (!filePath) return defaultLinkRenderer.call(this, token)
```

The link renderer moves to `lib/markdownLinkRenderer.ts`. The `renderer` vitest project runs in a `node` environment, so this logic was unreachable from tests while it lived inside the React component — the extraction is what makes the regression test possible.

## Verification

- New tests confirmed **red without the fix** (4 failures, the same `parseInline` TypeError) and green with it — covering plain links, inline formatting inside links, link titles, autolinks, and the existing file-link chrome.
- `pnpm test` — 249 passed, 15 skipped (the environment-dependent ones)
- `pnpm --filter polycode-electron typecheck` — clean
- `pnpm lint` — clean
- `pnpm run build` — succeeds

## Follow-ups (not in this PR)

Reviewing the logs surfaced three separate issues, handed off for investigation:

1. **Error boundary blast radius** — the only boundary over the transcript is at the app root, and its fallback has no `resetKeys`/retry, so any single message's failure kills the whole window unrecoverably. `PanelErrorBoundary` already exists but is wired only into `SecondPanel`. `renderEntry.tsx` is the natural seam for per-entry isolation.
2. **`polycode.db` is 4.88 GB** — not yet investigated.
3. **Auto-titling is broken in packaged builds** — the SDK's `claude.exe` isn't covered by `asarUnpack` in `apps/desktop/package.json`, and executables can't be spawned from inside an asar archive. Silent in every published build so far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
