### PR TITLE
fix: stop test and Electron runs clobbering each other's better-sqlite3 ABI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,23 @@ pnpm run mobile       # Expo dev server for apps/mobile
 
 `node apps/desktop/scripts/postinstall.js` runs on `pnpm install` (root postinstall) — it downloads the Electron binary and the Electron-ABI better-sqlite3 prebuilt. pnpm runs it with the project-managed Node 22 runtime. It resolves package dirs via `require.resolve`, so it works with root-hoisted node_modules.
 
+### better-sqlite3 ABI juggling
+
+`pnpm test` runs Vitest under plain Node, so it calls `prebuild-install` to put the
+**Node-ABI** binary in `node_modules/better-sqlite3/build/Release/`. Electron needs the
+**Electron-ABI** binary at that same path. The two overwrite each other, so running the
+tests leaves `dev`/`start`/`dist` with the wrong binary and Electron dies at startup on an
+ABI mismatch.
+
+Every Electron-running script therefore restores the right one first via
+`pnpm run electron-abi` (a thin wrapper over `postinstall.js`, which is idempotent and
+skips the download when the ABI-specific copy already exists). `test` re-installs the
+Node-ABI binary on its own, so both directions self-heal — don't "simplify" either by
+removing the guard.
+
+This matters most for `dist`: packaging straight after a test run would otherwise bake the
+Node-ABI binary into the installer and ship an app that crashes on launch.
+
 ## Desktop Architecture (`apps/desktop`)
 
 PolyCode is an Electron desktop app that provides a UI for orchestrating Claude Code CLI sessions. It has three layers:

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,15 +5,16 @@
   "main": "out/main/index.js",
   "author": "billpeet",
   "scripts": {
-    "dev": "electron-vite dev",
+    "electron-abi": "node scripts/postinstall.js",
+    "dev": "pnpm run electron-abi && electron-vite dev",
     "build": "electron-vite build",
     "preview": "electron-vite preview",
-    "start": "electron .",
-    "start:prod": "pnpm run build && cross-env NODE_ENV=production electron .",
+    "start": "pnpm run electron-abi && electron .",
+    "start:prod": "pnpm run build && pnpm run electron-abi && cross-env NODE_ENV=production electron .",
     "typecheck": "tsc --build --noEmit",
     "test": "pnpm --dir ../../node_modules/better-sqlite3 exec prebuild-install && vitest run",
-    "dist": "pnpm run build && electron-builder --win",
-    "dist:publish": "pnpm run build && electron-builder --win --publish always"
+    "dist": "pnpm run build && pnpm run electron-abi && electron-builder --win",
+    "dist:publish": "pnpm run build && pnpm run electron-abi && electron-builder --win --publish always"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.173",


### PR DESCRIPTION
## Problem

Vitest runs under plain Node, so `test` calls `prebuild-install` to drop the **Node-ABI** better-sqlite3 binary into `node_modules/better-sqlite3/build/Release/`. Electron needs the **Electron-ABI** binary at that exact same path.

Neither script restored what it needed, so whichever ran last won:

- run `pnpm test` → `pnpm dev` dies at startup on an ABI mismatch
- re-run `postinstall.js` to fix dev → the tests break instead

Verified by hash — `pnpm test` swaps `4a98…` (Electron ABI 140) for `4b59…` (Node ABI) on every single run.

**The serious case is `dist`.** Packaging straight after a test run baked the Node-ABI binary into the installer and shipped an app that crashes on launch. CI never hit it because `quality` and `build-windows` are separate jobs on separate machines with fresh installs — this only bites local builds.

## Fix

Add an `electron-abi` script wrapping the existing `postinstall.js` — already idempotent, and it skips the download when the ABI-specific copy is on disk, so the cost is two file copies. Run it from `dev`, `start`, `start:prod`, `dist` and `dist:publish`.

`test` already reinstalls the Node-ABI binary itself, so both directions now self-heal and the order you run things in stops mattering.

## Verification

- `pnpm test` → binary flips to Node ABI; `pnpm run electron-abi` → flips back. Confirmed by md5.
- `pnpm dev` launches cleanly, restoring the ABI automatically first; DB-backed IPC calls succeed with no mismatch.
- `ELECTRON_RUN_AS_NODE=1 electron -e "require('better-sqlite3')"` loads against ABI 140.
- `pnpm test` 249 passed / 15 skipped, `pnpm typecheck` clean across all 3 packages, `pnpm lint` clean.

The rationale is written up in `CLAUDE.md` so the guard doesn't get "simplified" away later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
