### PR TITLE
Route CLI calls through the Runner seam

### DIFF
--- a/apps/desktop/src/main/__tests__/forge-parsers.test.ts
+++ b/apps/desktop/src/main/__tests__/forge-parsers.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildAzurePullRequestUrl,
+  buildAzurePullRequestsUrl,
+  buildAzureRepoUrl,
+  mapAzurePr,
+  mapGitHubPr,
+  normalizeAzureBranchName,
+  parseAzureRemote,
+  parseGitHubRemote,
+} from '../forge-parsers'
+
+describe('GitHub parsers', () => {
+  it.each([
+    ['https://github.com/acme/repo.git', { owner: 'acme', repo: 'repo' }],
+    ['git@github.com:acme/repo.git', { owner: 'acme', repo: 'repo' }],
+    ['ssh://git@github.com/acme/my%20repo.git', { owner: 'acme', repo: 'my repo' }],
+    ['https://example.com/acme/repo', null],
+  ])('parses %s', (url, expected) => {
+    expect(parseGitHubRemote(url)).toEqual(expected)
+  })
+
+  it('maps defaults and normalizes status', () => {
+    expect(mapGitHubPr({ number: 7, state: 'OPEN', author: { login: 'ada' } })).toMatchObject({
+      id: 7,
+      title: '(untitled)',
+      status: 'open',
+      authorName: 'ada',
+    })
+  })
+})
+
+describe('Azure DevOps parsers', () => {
+  it.each([
+    ['https://dev.azure.com/org/project/_git/repo', 'project', 'repo'],
+    ['git@ssh.dev.azure.com:v3/org/project/repo', 'project', 'repo'],
+    ['ssh://git@vs-ssh.visualstudio.com:22/DefaultCollection/project/_ssh/repo', 'project', 'repo'],
+    ['https://dev.azure.com/org/_git/repo', null, 'repo'],
+  ])('parses %s', (url, project, repo) => {
+    expect(parseAzureRemote(url)).toMatchObject({ project, repo })
+  })
+
+  it('builds browser URLs from SSH remotes', () => {
+    const remote = 'git@ssh.dev.azure.com:v3/org/project/repo.git'
+    expect(buildAzureRepoUrl(remote)).toBe('https://dev.azure.com/org/project/_git/repo')
+    expect(buildAzurePullRequestsUrl(remote)).toBe('https://dev.azure.com/org/project/_git/repo/pullrequests')
+    expect(buildAzurePullRequestUrl(remote, 42)).toBe('https://dev.azure.com/org/project/_git/repo/pullrequest/42')
+  })
+
+  it('normalizes branches and maps pull requests', () => {
+    expect(normalizeAzureBranchName(' refs/remotes/origin/feature/x ', 'origin')).toBe('feature/x')
+    expect(mapAzurePr({
+      pullRequestId: 42,
+      sourceRefName: 'refs/heads/feature/x',
+      targetRefName: 'refs/heads/main',
+      createdBy: { displayName: 'Ada' },
+    }, 'git@ssh.dev.azure.com:v3/org/project/repo')).toMatchObject({
+      id: 42,
+      sourceBranch: 'feature/x',
+      targetBranch: 'main',
+      authorName: 'Ada',
+      url: 'https://dev.azure.com/org/project/_git/repo/pullrequest/42',
+    })
+  })
+})

--- a/apps/desktop/src/main/__tests__/git-parsers.test.ts
+++ b/apps/desktop/src/main/__tests__/git-parsers.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { parseCommitLog, parseNameStatus, parsePorcelainStatus } from '../git-parsers'
+
+describe('git parsers', () => {
+  it('parses name-status including scored renames and ignores malformed rows', () => {
+    expect(parseNameStatus('M\tsrc/a.ts\nR100\told.ts\tnew.ts\nX\tignored.ts\nR050\tmissing.ts')).toEqual([
+      { status: 'M', path: 'src/a.ts', staged: false },
+      { status: 'R', path: 'new.ts', oldPath: 'old.ts', staged: false },
+    ])
+  })
+
+  it('parses staged, unstaged, untracked, and renamed porcelain rows', () => {
+    expect(parsePorcelainStatus('M  staged.ts\n M unstaged.ts\nMM both.ts\n?? new.ts\nR  old.ts -> new.ts')).toEqual([
+      { status: 'M', path: 'staged.ts', staged: true },
+      { status: 'M', path: 'unstaged.ts', staged: false },
+      { status: 'M', path: 'both.ts', staged: true },
+      { status: 'M', path: 'both.ts', staged: false },
+      { status: '?', path: 'new.ts', staged: false },
+      { status: 'R', path: 'new.ts', oldPath: 'old.ts', staged: true },
+    ])
+  })
+
+  it('parses commit records including merges and tabs in subjects', () => {
+    const line = 'abcdef\tabc123\tAda\tada@example.com\t2026-07-29T09:00:00Z\tparent1 parent2\tSubject\twith tab'
+    expect(parseCommitLog(`${line}\nmalformed`)).toEqual([{
+      sha: 'abcdef',
+      shortSha: 'abc123',
+      authorName: 'Ada',
+      authorEmail: 'ada@example.com',
+      authorDate: '2026-07-29T09:00:00Z',
+      parents: ['parent1', 'parent2'],
+      subject: 'Subject\twith tab',
+    }])
+  })
+})

--- a/apps/desktop/src/main/__tests__/git-runner.test.ts
+++ b/apps/desktop/src/main/__tests__/git-runner.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+import { FakeRunner } from '../driver/runner/fake'
+import { GitCommandError, GitLockedError, extractLockPathFromStderr, runGit } from '../git-runner'
+
+describe('extractLockPathFromStderr', () => {
+  it.each([
+    ["fatal: Unable to create 'C:/repo/.git/index.lock': File exists.", 'C:/repo/.git/index.lock'],
+    ['Another git process seems to be running in this repository', 'index.lock'],
+    ["fatal: cannot lock ref 'refs/heads/main': Unable to create '/repo/.git/refs/heads/main.lock': File exists.", '/repo/.git/refs/heads/main.lock'],
+    ['fatal: not a git repository', null],
+  ])('extracts a lock path from %s', (stderr, expected) => {
+    expect(extractLockPathFromStderr(stderr)).toBe(expected)
+  })
+})
+
+describe('runGit', () => {
+  it('runs a semantic git command and trims only trailing whitespace', async () => {
+    const runner = new FakeRunner('wsl')
+    runner.queueResult({ stdout: '  value\n' })
+
+    await expect(runGit(runner, '/repo', ['status', '--short'])).resolves.toBe('  value')
+    expect(runner.runCommands).toEqual([{
+      binary: 'git',
+      args: ['status', '--short'],
+      workDir: '/repo',
+      maxOutputBytes: 4 * 1024 * 1024,
+    }])
+  })
+
+  it('retries lock contention with quadratic backoff', async () => {
+    const runner = new FakeRunner()
+    runner.queueResult({ stderr: "fatal: Unable to create '/repo/.git/index.lock': File exists.", exitCode: 128 })
+    runner.queueResult({ stderr: 'Another git process seems to be running in this repository', exitCode: 128 })
+    runner.queueResult({ stdout: 'ok\n' })
+    const delay = vi.fn(async () => undefined)
+
+    await expect(runGit(runner, '/repo', ['fetch'], { delay })).resolves.toBe('ok')
+    expect(delay.mock.calls).toEqual([[50], [200]])
+    expect(runner.runCommands).toHaveLength(3)
+  })
+
+  it('throws GitLockedError after the final lock failure', async () => {
+    const runner = new FakeRunner()
+    runner.queueResult({ stderr: 'Another git process seems to be running in this repository', exitCode: 128 })
+    runner.queueResult({ stderr: 'Another git process seems to be running in this repository', exitCode: 128 })
+
+    await expect(runGit(runner, '/repo', ['checkout', 'main'], {
+      maxAttempts: 2,
+      delay: async () => undefined,
+    })).rejects.toMatchObject<Partial<GitLockedError>>({
+      name: 'GitLockedError',
+      lockPath: 'index.lock',
+    })
+  })
+
+  it('throws a stderr-bearing error without retrying other failures', async () => {
+    const runner = new FakeRunner()
+    runner.queueResult({ stdout: 'partial', stderr: 'fatal: bad revision', exitCode: 128 })
+
+    await expect(runGit(runner, '/repo', ['show', 'missing'])).rejects.toMatchObject<Partial<GitCommandError>>({
+      name: 'GitCommandError',
+      stdout: 'partial',
+      stderr: 'fatal: bad revision',
+      exitCode: 128,
+    })
+    expect(runner.runCommands).toHaveLength(1)
+  })
+})

--- a/apps/desktop/src/main/azure-devops.ts
+++ b/apps/desktop/src/main/azure-devops.ts
@@ -1,278 +1,48 @@
-import { spawn, execFile } from 'child_process'
-import { promisify } from 'util'
 import { existsSync } from 'fs'
 import * as path from 'path'
 import { AzureDevOpsPullRequest, SshConfig, WslConfig } from '../shared/types'
-import { augmentWindowsPath, winQuote } from './driver/runner'
-import { sshExec } from './ssh'
-import { wslExec } from './wsl'
+import { createRunner } from './driver/runner'
+import { runGit } from './git-runner'
+import {
+  buildAzurePullRequestsUrl as buildPullRequestsWebUrl,
+  buildAzureRepoUrl as buildRepoWebUrl,
+  mapAzurePr as mapPr,
+  normalizeAzureBranchName as normalizeBranchName,
+  parseAzureRemote,
+} from './forge-parsers'
 
-const execFileAsync = promisify(execFile)
-
-interface AzureRepoContext {
-  remoteName: string
-  project: string | null
-  repo: string
-  remoteUrl: string
-}
-
-interface AzDevOpsPr {
-  pullRequestId?: number
-  title?: string
-  status?: string
-  sourceRefName?: string
-  targetRefName?: string
-  createdBy?: { displayName?: string }
-  url?: string
-  creationDate?: string
-}
-
-interface SpawnResult {
-  stdout: string
-  stderr: string
-  code: number | null
-}
+import type { AzureRepoContext, AzurePrInput as AzDevOpsPr } from './forge-parsers'
 
 interface LocalCommand {
   cmd: string
   args: string[]
-  shell: boolean
 }
 
-function shortRef(ref: string | undefined): string {
-  if (!ref) return ''
-  return ref.replace(/^refs\/heads\//, '')
-}
-
-function normalizeBranchName(branch: string, remoteName: string): string {
-  const trimmed = branch.trim()
-  if (!trimmed) return ''
-
-  return trimmed
-    .replace(/^refs\/heads\//, '')
-    .replace(/^refs\/remotes\//, '')
-    .replace(/^remotes\//, '')
-    .replace(new RegExp(`^${remoteName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/`), '')
-}
-
-function buildWebUrl(remoteUrl: string, prId: number): string {
-  const normalized = remoteUrl.replace(/\.git$/i, '').replace(/\/+$/, '')
-
-  // SSH: git@ssh.dev.azure.com:v3/org/project/repo
-  const sshMatch = normalized.match(/^git@ssh\.dev\.azure\.com:v3\/([^/]+)\/([^/]+)\/([^/]+)$/i)
-  if (sshMatch) return `https://dev.azure.com/${sshMatch[1]}/${sshMatch[2]}/_git/${sshMatch[3]}/pullrequest/${prId}`
-
-  // SSH: ssh://git@ssh.dev.azure.com/v3/org/project/repo
-  const sshUrlMatch = normalized.match(/^ssh:\/\/git@ssh\.dev\.azure\.com\/v3\/([^/]+)\/([^/]+)\/([^/]+)$/i)
-  if (sshUrlMatch) return `https://dev.azure.com/${sshUrlMatch[1]}/${sshUrlMatch[2]}/_git/${sshUrlMatch[3]}/pullrequest/${prId}`
-
-  // SSH: git@vs-ssh.visualstudio.com:v3/org/project/repo
-  const vsSshMatch = normalized.match(/^git@vs-ssh\.visualstudio\.com:v3\/([^/]+)\/([^/]+)\/([^/]+)$/i)
-  if (vsSshMatch) return `https://${vsSshMatch[1]}.visualstudio.com/${vsSshMatch[2]}/_git/${vsSshMatch[3]}/pullrequest/${prId}`
-
-  // HTTPS: just append /pullrequest/<id> to the repo URL
-  return `${normalized}/pullrequest/${prId}`
-}
-
-function buildPullRequestsWebUrl(remoteUrl: string): string {
-  const normalized = remoteUrl.replace(/\.git$/i, '').replace(/\/+$/, '')
-
-  // SSH: git@ssh.dev.azure.com:v3/org/project/repo
-  const sshMatch = normalized.match(/^git@ssh\.dev\.azure\.com:v3\/([^/]+)\/([^/]+)\/([^/]+)$/i)
-  if (sshMatch) return `https://dev.azure.com/${sshMatch[1]}/${sshMatch[2]}/_git/${sshMatch[3]}/pullrequests`
-
-  // SSH: ssh://git@ssh.dev.azure.com/v3/org/project/repo
-  const sshUrlMatch = normalized.match(/^ssh:\/\/git@ssh\.dev\.azure\.com\/v3\/([^/]+)\/([^/]+)\/([^/]+)$/i)
-  if (sshUrlMatch) return `https://dev.azure.com/${sshUrlMatch[1]}/${sshUrlMatch[2]}/_git/${sshUrlMatch[3]}/pullrequests`
-
-  // SSH: git@vs-ssh.visualstudio.com:v3/org/project/repo
-  const vsSshMatch = normalized.match(/^git@vs-ssh\.visualstudio\.com:v3\/([^/]+)\/([^/]+)\/([^/]+)$/i)
-  if (vsSshMatch) return `https://${vsSshMatch[1]}.visualstudio.com/${vsSshMatch[2]}/_git/${vsSshMatch[3]}/pullrequests`
-
-  // HTTPS: just append /pullrequests to the repo URL
-  return `${normalized}/pullrequests`
-}
-
-function buildRepoWebUrl(remoteUrl: string): string {
-  const normalized = remoteUrl.replace(/\.git$/i, '').replace(/\/+$/, '')
-
-  // SSH: git@ssh.dev.azure.com:v3/org/project/repo
-  const sshMatch = normalized.match(/^git@ssh\.dev\.azure\.com:v3\/([^/]+)\/([^/]+)\/([^/]+)$/i)
-  if (sshMatch) return `https://dev.azure.com/${sshMatch[1]}/${sshMatch[2]}/_git/${sshMatch[3]}`
-
-  // SSH: ssh://git@ssh.dev.azure.com/v3/org/project/repo
-  const sshUrlMatch = normalized.match(/^ssh:\/\/git@ssh\.dev\.azure\.com\/v3\/([^/]+)\/([^/]+)\/([^/]+)$/i)
-  if (sshUrlMatch) return `https://dev.azure.com/${sshUrlMatch[1]}/${sshUrlMatch[2]}/_git/${sshUrlMatch[3]}`
-
-  // SSH: git@vs-ssh.visualstudio.com:v3/org/project/repo
-  const vsSshMatch = normalized.match(/^git@vs-ssh\.visualstudio\.com:v3\/([^/]+)\/([^/]+)\/([^/]+)$/i)
-  if (vsSshMatch) return `https://${vsSshMatch[1]}.visualstudio.com/${vsSshMatch[2]}/_git/${vsSshMatch[3]}`
-
-  return normalized
-}
-
-function mapPr(pr: AzDevOpsPr, remoteUrl?: string): AzureDevOpsPullRequest {
-  const id = pr.pullRequestId ?? 0
-  const url = remoteUrl && id ? buildWebUrl(remoteUrl, id) : (pr.url ?? '')
-  return {
-    id,
-    title: pr.title ?? '(untitled)',
-    status: pr.status ?? 'unknown',
-    sourceBranch: shortRef(pr.sourceRefName),
-    targetBranch: shortRef(pr.targetRefName),
-    authorName: pr.createdBy?.displayName ?? 'Unknown',
-    url,
-    creationDate: pr.creationDate ?? '',
-  }
-}
-
-function parseAzureRemote(remoteUrl: string): AzureRepoContext | null {
-  const normalized = remoteUrl.replace(/\.git$/i, '')
-
-  // https://dev.azure.com/org/project/_git/repo
-  // https://org@dev.azure.com/org/project/_git/repo
-  const httpsMatch = normalized.match(/^https:\/\/(?:[^@/]+@)?dev\.azure\.com\/([^/]+)\/([^/]+)\/_git\/([^/?#]+)(?:[/?#].*)?$/i)
-  if (httpsMatch) {
-    return {
-      remoteName: 'origin',
-      project: decodeURIComponent(httpsMatch[2] ?? ''),
-      repo: decodeURIComponent(httpsMatch[3] ?? ''),
-      remoteUrl,
-    }
-  }
-
-  // https://dev.azure.com/org/_git/repo (project implied by azdevops default config)
-  const httpsNoProjectMatch = normalized.match(/^https:\/\/(?:[^@/]+@)?dev\.azure\.com\/([^/]+)\/_git\/([^/?#]+)(?:[/?#].*)?$/i)
-  if (httpsNoProjectMatch) {
-    return {
-      remoteName: 'origin',
-      project: null,
-      repo: decodeURIComponent(httpsNoProjectMatch[2] ?? ''),
-      remoteUrl,
-    }
-  }
-
-  // https://org.visualstudio.com/project/_git/repo
-  // https://org.visualstudio.com/DefaultCollection/project/_git/repo
-  const visualStudioMatch = normalized.match(/^https:\/\/([^.]+)\.visualstudio\.com\/(?:(?:DefaultCollection)\/)?([^/]+)\/_git\/([^/?#]+)(?:[/?#].*)?$/i)
-  if (visualStudioMatch) {
-    return {
-      remoteName: 'origin',
-      project: decodeURIComponent(visualStudioMatch[2] ?? ''),
-      repo: decodeURIComponent(visualStudioMatch[3] ?? ''),
-      remoteUrl,
-    }
-  }
-
-  // https://org.visualstudio.com/_git/repo (project implied by azdevops default config)
-  const visualStudioNoProjectMatch = normalized.match(/^https:\/\/([^.]+)\.visualstudio\.com\/_git\/([^/?#]+)(?:[/?#].*)?$/i)
-  if (visualStudioNoProjectMatch) {
-    return {
-      remoteName: 'origin',
-      project: null,
-      repo: decodeURIComponent(visualStudioNoProjectMatch[2] ?? ''),
-      remoteUrl,
-    }
-  }
-
-  // git@ssh.dev.azure.com:v3/org/project/repo
-  const sshMatch = normalized.match(/^git@ssh\.dev\.azure\.com:v3\/([^/]+)\/([^/]+)\/([^/?#]+)(?:[/?#].*)?$/i)
-  if (sshMatch) {
-    return {
-      remoteName: 'origin',
-      project: decodeURIComponent(sshMatch[2] ?? ''),
-      repo: decodeURIComponent(sshMatch[3] ?? ''),
-      remoteUrl,
-    }
-  }
-
-  // ssh://git@ssh.dev.azure.com/v3/org/project/repo
-  const sshUrlMatch = normalized.match(/^ssh:\/\/git@ssh\.dev\.azure\.com\/v3\/([^/]+)\/([^/]+)\/([^/?#]+)(?:[/?#].*)?$/i)
-  if (sshUrlMatch) {
-    return {
-      remoteName: 'origin',
-      project: decodeURIComponent(sshUrlMatch[2] ?? ''),
-      repo: decodeURIComponent(sshUrlMatch[3] ?? ''),
-      remoteUrl,
-    }
-  }
-
-  // git@vs-ssh.visualstudio.com:v3/org/project/repo
-  const vsSshMatch = normalized.match(/^git@vs-ssh\.visualstudio\.com:v3\/([^/]+)\/([^/]+)\/([^/?#]+)(?:[/?#].*)?$/i)
-  if (vsSshMatch) {
-    return {
-      remoteName: 'origin',
-      project: decodeURIComponent(vsSshMatch[2] ?? ''),
-      repo: decodeURIComponent(vsSshMatch[3] ?? ''),
-      remoteUrl,
-    }
-  }
-
-  // ssh://git@vs-ssh.visualstudio.com:22/DefaultCollection/project/_ssh/repo
-  const vsOldSshMatch = normalized.match(/^ssh:\/\/git@vs-ssh\.visualstudio\.com(?::\d+)?\/DefaultCollection\/([^/]+)\/_ssh\/([^/?#]+)(?:[/?#].*)?$/i)
-  if (vsOldSshMatch) {
-    return {
-      remoteName: 'origin',
-      project: decodeURIComponent(vsOldSshMatch[1] ?? ''),
-      repo: decodeURIComponent(vsOldSshMatch[2] ?? ''),
-      remoteUrl,
-    }
-  }
-
-  return null
-}
-
-async function runLocal(cmd: string, args: string[], cwd: string): Promise<SpawnResult> {
+async function runLocal(cmd: string, args: string[], cwd: string) {
   const command = await resolveLocalCommand(cmd, args)
-
-  return new Promise((resolve) => {
-    const isWindows = process.platform === 'win32'
-    const proc = isWindows && command.shell
-      ? spawn([command.cmd, ...command.args.map(winQuote)].join(' '), [], {
-        cwd,
-        // On Windows, global CLIs are often .cmd shims and need shell resolution.
-        shell: true,
-        env: augmentWindowsPath(),
-        stdio: ['ignore', 'pipe', 'pipe'],
-      })
-      : spawn(command.cmd, command.args, {
-        cwd,
-        shell: false,
-        env: process.platform === 'win32' ? augmentWindowsPath() : process.env,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      })
-
-    let stdout = ''
-    let stderr = ''
-
-    proc.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8') })
-    proc.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8') })
-
-    proc.on('close', (code) => {
-      resolve({ stdout: stdout.trim(), stderr: stderr.trim(), code })
-    })
-
-    proc.on('error', (err) => {
-      resolve({ stdout: '', stderr: err.message, code: null })
-    })
-  })
+  return createRunner({}).run({ binary: command.cmd, args: command.args, workDir: cwd })
 }
 
 async function resolveLocalCommand(cmd: string, args: string[]): Promise<LocalCommand> {
-  if (process.platform !== 'win32') return { cmd, args, shell: false }
+  if (process.platform !== 'win32') return { cmd, args }
 
-  if (cmd !== 'azdevops') return { cmd, args, shell: true }
+  if (cmd !== 'azdevops') return { cmd, args }
 
   const direct = await resolveWindowsAzDevOpsNodeCommand(args)
   if (direct) return direct
 
-  return { cmd, args, shell: true }
+  return { cmd, args }
 }
 
 async function resolveWindowsAzDevOpsNodeCommand(args: string[]): Promise<LocalCommand | null> {
   try {
-    const { stdout } = await execFileAsync('where.exe', ['azdevops.cmd'], { env: augmentWindowsPath() })
-    const cmdPath = stdout.split(/\r?\n/).map((line) => line.trim()).find(Boolean)
+    const result = await createRunner({}).run({
+      binary: 'where.exe',
+      args: ['azdevops.cmd'],
+      workDir: process.cwd(),
+    })
+    if (result.exitCode !== 0) return null
+    const cmdPath = result.stdout.split(/\r?\n/).map((line) => line.trim()).find(Boolean)
     if (!cmdPath) return null
 
     const baseDir = path.dirname(cmdPath)
@@ -283,7 +53,6 @@ async function resolveWindowsAzDevOpsNodeCommand(args: string[]): Promise<LocalC
     return {
       cmd: existsSync(adjacentNode) ? adjacentNode : 'node',
       args: [scriptPath, ...args],
-      shell: false,
     }
   } catch {
     return null
@@ -291,29 +60,18 @@ async function resolveWindowsAzDevOpsNodeCommand(args: string[]): Promise<LocalC
 }
 
 async function git(repoPath: string, args: string[], ssh?: SshConfig | null, wsl?: WslConfig | null): Promise<string> {
-  const gitCmd = `git ${args.map(a => "'" + a.replace(/'/g, "'\\''") + "'").join(' ')}`
-  if (ssh) return sshExec(ssh, repoPath, gitCmd)
-  if (wsl) return wslExec(wsl, repoPath, gitCmd)
-  const { stdout } = await execFileAsync('git', args, { cwd: repoPath, maxBuffer: 4 * 1024 * 1024 })
-  return stdout.trimEnd()
+  return runGit(createRunner({ ssh: ssh ?? undefined, wsl: wsl ?? undefined }), repoPath, args)
 }
 
 async function runAzDevOps(repoPath: string, args: string[], ssh?: SshConfig | null, wsl?: WslConfig | null): Promise<string> {
-  const quoted = args.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(' ')
-
-  if (ssh) {
-    const output = await sshExec(ssh, repoPath, `azdevops ${quoted}`)
-    return output.trim()
-  }
-
-  if (wsl) {
-    const output = await wslExec(wsl, repoPath, `azdevops ${quoted}`)
-    return output.trim()
-  }
-
-  const cmd = 'azdevops'
-  const result = await runLocal(cmd, args, repoPath)
-  if (result.code !== 0) {
+  const result = ssh || wsl
+    ? await createRunner({ ssh: ssh ?? undefined, wsl: wsl ?? undefined }).run({
+      binary: 'azdevops',
+      args,
+      workDir: repoPath,
+    })
+    : await runLocal('azdevops', args, repoPath)
+  if (result.exitCode !== 0) {
     if (/ENOENT|EINVAL|not found|is not recognized/i.test(result.stderr)) {
       throw new Error('azdevops CLI not found. Install and configure it first: azdevops setup --org <org> --token <pat> --project <project>')
     }
@@ -322,7 +80,7 @@ async function runAzDevOps(repoPath: string, args: string[], ssh?: SshConfig | n
     }
     throw new Error(result.stderr || 'Failed to execute azdevops CLI')
   }
-  return result.stdout
+  return result.stdout.trim()
 }
 
 async function resolveRepoContext(repoPath: string, ssh?: SshConfig | null, wsl?: WslConfig | null): Promise<AzureRepoContext> {

--- a/apps/desktop/src/main/driver/__tests__/runner-run.test.ts
+++ b/apps/desktop/src/main/driver/__tests__/runner-run.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { LocalRunner } from '../runner/local'
+import { FakeRunner } from '../runner/fake'
+
+const workDir = process.cwd()
+
+describe('Runner.run', () => {
+  it('collects stdout, stderr, and a non-zero exit as data', async () => {
+    const runner = new LocalRunner()
+    const result = process.platform === 'win32'
+      ? await runner.run({
+        binary: 'cmd',
+        args: ['/d', '/s', '/c', 'echo out & echo err 1>&2 & exit /b 7'],
+        workDir,
+      })
+      : await runner.run({
+        binary: 'sh',
+        args: ['-c', 'printf out; printf err >&2; exit 7'],
+        workDir,
+      })
+
+    expect(result.stdout.trim()).toBe('out')
+    expect(result.stderr.trim()).toBe('err')
+    expect(result.exitCode).toBe(7)
+    expect(result.timedOut).toBe(false)
+  })
+
+  it('returns a timed-out result', async () => {
+    const runner = new LocalRunner()
+    const result = process.platform === 'win32'
+      ? await runner.run({
+        binary: 'powershell',
+        args: ['-NonInteractive', '-Command', 'Start-Sleep -Seconds 2'],
+        workDir,
+        timeoutMs: 10,
+      })
+      : await runner.run({
+        binary: 'sh',
+        args: ['-c', 'sleep 2'],
+        workDir,
+        timeoutMs: 10,
+      })
+
+    expect(result.exitCode).toBeNull()
+    expect(result.timedOut).toBe(true)
+  })
+})
+
+describe('FakeRunner', () => {
+  it('records semantic run commands and returns queued results', async () => {
+    const runner = new FakeRunner('ssh')
+    runner.queueResult({ stdout: 'ok\n' })
+
+    const command = { binary: 'git', args: ['status'], workDir }
+    await expect(runner.run(command)).resolves.toMatchObject({ stdout: 'ok\n', exitCode: 0 })
+    expect(runner.runCommands).toEqual([command])
+    expect(runner.type).toBe('ssh')
+  })
+})

--- a/apps/desktop/src/main/driver/runner/collect.ts
+++ b/apps/desktop/src/main/driver/runner/collect.ts
@@ -1,0 +1,51 @@
+import type { ChildProcess } from 'child_process'
+import type { RunCommand, RunResult } from './types'
+
+const DEFAULT_MAX_OUTPUT_BYTES = 4 * 1024 * 1024
+
+export function collectProcess(proc: ChildProcess, command: RunCommand): Promise<RunResult> {
+  return new Promise((resolve) => {
+    let stdout = ''
+    let stderr = ''
+    let outputBytes = 0
+    let settled = false
+    let timedOut = false
+    const maxOutputBytes = command.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES
+
+    const finish = (exitCode: number | null): void => {
+      if (settled) return
+      settled = true
+      if (timer) clearTimeout(timer)
+      resolve({ stdout, stderr, exitCode, timedOut })
+    }
+
+    const append = (target: 'stdout' | 'stderr', chunk: Buffer): void => {
+      if (settled) return
+      outputBytes += chunk.byteLength
+      if (outputBytes > maxOutputBytes) {
+        stderr += `${stderr ? '\n' : ''}Process output exceeded ${maxOutputBytes} bytes`
+        try { proc.kill('SIGTERM') } catch { /* ignore */ }
+        finish(null)
+        return
+      }
+      if (target === 'stdout') stdout += chunk.toString('utf8')
+      else stderr += chunk.toString('utf8')
+    }
+
+    proc.stdout?.on('data', (chunk: Buffer) => append('stdout', chunk))
+    proc.stderr?.on('data', (chunk: Buffer) => append('stderr', chunk))
+    proc.on('close', (code) => finish(code))
+    proc.on('error', (error) => {
+      stderr += `${stderr ? '\n' : ''}${error.message}`
+      finish(null)
+    })
+
+    const timer = command.timeoutMs === undefined
+      ? undefined
+      : setTimeout(() => {
+        timedOut = true
+        try { proc.kill('SIGTERM') } catch { /* ignore */ }
+        finish(null)
+      }, command.timeoutMs)
+  })
+}

--- a/apps/desktop/src/main/driver/runner/fake.ts
+++ b/apps/desktop/src/main/driver/runner/fake.ts
@@ -1,0 +1,38 @@
+import { EventEmitter } from 'events'
+import type { ChildProcess } from 'child_process'
+import type { Runner, RunCommand, RunResult, SpawnCommand } from './types'
+
+export class FakeRunner implements Runner {
+  readonly type: Runner['type']
+  readonly spawned: SpawnCommand[] = []
+  readonly runCommands: RunCommand[] = []
+  private readonly results: RunResult[] = []
+
+  constructor(type: Runner['type'] = 'local') {
+    this.type = type
+  }
+
+  queueResult(result: Partial<RunResult> = {}): void {
+    this.results.push({
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+      exitCode: result.exitCode ?? 0,
+      timedOut: result.timedOut ?? false,
+    })
+  }
+
+  spawn(command: SpawnCommand): ChildProcess {
+    this.spawned.push(command)
+    return new EventEmitter() as ChildProcess
+  }
+
+  async run(command: RunCommand): Promise<RunResult> {
+    this.runCommands.push(command)
+    return this.results.shift() ?? {
+      stdout: '',
+      stderr: '',
+      exitCode: 0,
+      timedOut: false,
+    }
+  }
+}

--- a/apps/desktop/src/main/driver/runner/index.ts
+++ b/apps/desktop/src/main/driver/runner/index.ts
@@ -10,5 +10,5 @@ export function createRunner(opts: Pick<DriverOptions, 'ssh' | 'wsl'>): Runner {
   return new LocalRunner()
 }
 
-export type { Runner, SpawnCommand } from './types'
+export type { Runner, RunCommand, RunResult, SpawnCommand } from './types'
 export { shellEscape, winQuote, cdTarget, buildSshBaseArgs, LOAD_NODE_MANAGERS, FIX_HOME, RESOLVE_CODEX_BIN, RESOLVE_CODEX_BIN_SOFT, augmentWindowsPath, resolveClaudeCodeExecutable, expandHomePath } from './utils'

--- a/apps/desktop/src/main/driver/runner/local.ts
+++ b/apps/desktop/src/main/driver/runner/local.ts
@@ -2,11 +2,16 @@ import { spawn, ChildProcess } from 'child_process'
 import { writeFileSync, unlinkSync, existsSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { Runner, SpawnCommand } from './types'
+import { Runner, RunCommand, RunResult, SpawnCommand } from './types'
 import { winQuote, augmentWindowsPath } from './utils'
+import { collectProcess } from './collect'
 
 export class LocalRunner implements Runner {
   readonly type = 'local' as const
+
+  run(cmd: RunCommand): Promise<RunResult> {
+    return collectProcess(this.spawn(cmd), cmd)
+  }
 
   spawn(cmd: SpawnCommand): ChildProcess {
     const { binary, args, workDir, stdinContent, keepStdinOpen } = cmd

--- a/apps/desktop/src/main/driver/runner/ssh.ts
+++ b/apps/desktop/src/main/driver/runner/ssh.ts
@@ -1,12 +1,17 @@
 import { spawn, ChildProcess } from 'child_process'
 import { SshConfig } from '../../../shared/types'
-import { Runner, SpawnCommand } from './types'
+import { Runner, RunCommand, RunResult, SpawnCommand } from './types'
 import { shellEscape, cdTarget, buildSshBaseArgs, LOAD_NODE_MANAGERS } from './utils'
+import { collectProcess } from './collect'
 
 export class SshRunner implements Runner {
   readonly type = 'ssh' as const
 
   constructor(private readonly ssh: SshConfig) {}
+
+  run(cmd: RunCommand): Promise<RunResult> {
+    return collectProcess(this.spawn(cmd), cmd)
+  }
 
   spawn(cmd: SpawnCommand): ChildProcess {
     const { binary, args, workDir, preamble, stdinContent, keepStdinOpen } = cmd

--- a/apps/desktop/src/main/driver/runner/types.ts
+++ b/apps/desktop/src/main/driver/runner/types.ts
@@ -16,7 +16,22 @@ export interface SpawnCommand {
   keepStdinOpen?: boolean
 }
 
+export interface RunCommand extends SpawnCommand {
+  /** Kill the process and return a timed-out result after this duration. */
+  timeoutMs?: number
+  /** Stop collecting and kill the process if stdout + stderr exceed this size. */
+  maxOutputBytes?: number
+}
+
+export interface RunResult {
+  stdout: string
+  stderr: string
+  exitCode: number | null
+  timedOut: boolean
+}
+
 export interface Runner {
   readonly type: 'local' | 'wsl' | 'ssh'
   spawn(cmd: SpawnCommand): ChildProcess
+  run(cmd: RunCommand): Promise<RunResult>
 }

--- a/apps/desktop/src/main/driver/runner/wsl.ts
+++ b/apps/desktop/src/main/driver/runner/wsl.ts
@@ -1,12 +1,17 @@
 import { spawn, ChildProcess } from 'child_process'
 import { WslConfig } from '../../../shared/types'
-import { Runner, SpawnCommand } from './types'
+import { Runner, RunCommand, RunResult, SpawnCommand } from './types'
 import { shellEscape, cdTarget } from './utils'
+import { collectProcess } from './collect'
 
 export class WslRunner implements Runner {
   readonly type = 'wsl' as const
 
   constructor(private readonly wsl: WslConfig) {}
+
+  run(cmd: RunCommand): Promise<RunResult> {
+    return collectProcess(this.spawn(cmd), cmd)
+  }
 
   spawn(cmd: SpawnCommand): ChildProcess {
     const { binary, args, workDir, preamble, stdinContent, keepStdinOpen } = cmd

--- a/apps/desktop/src/main/forge-parsers.ts
+++ b/apps/desktop/src/main/forge-parsers.ts
@@ -1,0 +1,128 @@
+import type { AzureDevOpsPullRequest, GitHubPullRequest } from '../shared/types'
+
+export interface GitHubRemote {
+  owner: string
+  repo: string
+}
+
+export interface AzureRepoContext {
+  remoteName: string
+  project: string | null
+  repo: string
+  remoteUrl: string
+}
+
+export interface GitHubPrInput {
+  number?: number
+  title?: string
+  state?: string
+  headRefName?: string
+  baseRefName?: string
+  author?: { login?: string; name?: string }
+  url?: string
+  createdAt?: string
+}
+
+export interface AzurePrInput {
+  pullRequestId?: number
+  title?: string
+  status?: string
+  sourceRefName?: string
+  targetRefName?: string
+  createdBy?: { displayName?: string }
+  url?: string
+  creationDate?: string
+}
+
+export function parseGitHubRemote(remoteUrl: string): GitHubRemote | null {
+  const normalized = remoteUrl.replace(/\.git$/i, '')
+  const match = normalized.match(/^https:\/\/(?:[^@/]+@)?github\.com\/([^/]+)\/([^/?#]+)(?:[/?#].*)?$/i)
+    ?? normalized.match(/^git@github\.com:([^/]+)\/([^/?#]+)(?:[/?#].*)?$/i)
+    ?? normalized.match(/^ssh:\/\/git@github\.com\/([^/]+)\/([^/?#]+)(?:[/?#].*)?$/i)
+  return match ? { owner: decodeURIComponent(match[1] ?? ''), repo: decodeURIComponent(match[2] ?? '') } : null
+}
+
+export function mapGitHubPr(pr: GitHubPrInput): GitHubPullRequest {
+  return {
+    id: pr.number ?? 0,
+    title: pr.title ?? '(untitled)',
+    status: (pr.state ?? 'UNKNOWN').toLowerCase(),
+    sourceBranch: pr.headRefName ?? '',
+    targetBranch: pr.baseRefName ?? '',
+    authorName: pr.author?.name ?? pr.author?.login ?? 'Unknown',
+    url: pr.url ?? '',
+    creationDate: pr.createdAt ?? '',
+  }
+}
+
+export function normalizeAzureBranchName(branch: string, remoteName: string): string {
+  const trimmed = branch.trim()
+  if (!trimmed) return ''
+  return trimmed
+    .replace(/^refs\/heads\//, '')
+    .replace(/^refs\/remotes\//, '')
+    .replace(/^remotes\//, '')
+    .replace(new RegExp(`^${remoteName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/`), '')
+}
+
+function normalizedAzureRepoUrl(remoteUrl: string): string {
+  const normalized = remoteUrl.replace(/\.git$/i, '').replace(/\/+$/, '')
+  const match = normalized.match(/^git@ssh\.dev\.azure\.com:v3\/([^/]+)\/([^/]+)\/([^/]+)$/i)
+    ?? normalized.match(/^ssh:\/\/git@ssh\.dev\.azure\.com\/v3\/([^/]+)\/([^/]+)\/([^/]+)$/i)
+  if (match) return `https://dev.azure.com/${match[1]}/${match[2]}/_git/${match[3]}`
+  const legacy = normalized.match(/^git@vs-ssh\.visualstudio\.com:v3\/([^/]+)\/([^/]+)\/([^/]+)$/i)
+  if (legacy) return `https://${legacy[1]}.visualstudio.com/${legacy[2]}/_git/${legacy[3]}`
+  return normalized
+}
+
+export function buildAzurePullRequestUrl(remoteUrl: string, prId: number): string {
+  return `${normalizedAzureRepoUrl(remoteUrl)}/pullrequest/${prId}`
+}
+
+export function buildAzurePullRequestsUrl(remoteUrl: string): string {
+  return `${normalizedAzureRepoUrl(remoteUrl)}/pullrequests`
+}
+
+export function buildAzureRepoUrl(remoteUrl: string): string {
+  return normalizedAzureRepoUrl(remoteUrl)
+}
+
+export function mapAzurePr(pr: AzurePrInput, remoteUrl?: string): AzureDevOpsPullRequest {
+  const id = pr.pullRequestId ?? 0
+  return {
+    id,
+    title: pr.title ?? '(untitled)',
+    status: pr.status ?? 'unknown',
+    sourceBranch: pr.sourceRefName?.replace(/^refs\/heads\//, '') ?? '',
+    targetBranch: pr.targetRefName?.replace(/^refs\/heads\//, '') ?? '',
+    authorName: pr.createdBy?.displayName ?? 'Unknown',
+    url: remoteUrl && id ? buildAzurePullRequestUrl(remoteUrl, id) : (pr.url ?? ''),
+    creationDate: pr.creationDate ?? '',
+  }
+}
+
+export function parseAzureRemote(remoteUrl: string): AzureRepoContext | null {
+  const normalized = remoteUrl.replace(/\.git$/i, '')
+  const patterns: Array<{ regex: RegExp; project: number | null; repo: number }> = [
+    { regex: /^https:\/\/(?:[^@/]+@)?dev\.azure\.com\/([^/]+)\/([^/]+)\/_git\/([^/?#]+)(?:[/?#].*)?$/i, project: 2, repo: 3 },
+    { regex: /^https:\/\/(?:[^@/]+@)?dev\.azure\.com\/([^/]+)\/_git\/([^/?#]+)(?:[/?#].*)?$/i, project: null, repo: 2 },
+    { regex: /^https:\/\/([^.]+)\.visualstudio\.com\/(?:(?:DefaultCollection)\/)?([^/]+)\/_git\/([^/?#]+)(?:[/?#].*)?$/i, project: 2, repo: 3 },
+    { regex: /^https:\/\/([^.]+)\.visualstudio\.com\/_git\/([^/?#]+)(?:[/?#].*)?$/i, project: null, repo: 2 },
+    { regex: /^git@ssh\.dev\.azure\.com:v3\/([^/]+)\/([^/]+)\/([^/?#]+)(?:[/?#].*)?$/i, project: 2, repo: 3 },
+    { regex: /^ssh:\/\/git@ssh\.dev\.azure\.com\/v3\/([^/]+)\/([^/]+)\/([^/?#]+)(?:[/?#].*)?$/i, project: 2, repo: 3 },
+    { regex: /^git@vs-ssh\.visualstudio\.com:v3\/([^/]+)\/([^/]+)\/([^/?#]+)(?:[/?#].*)?$/i, project: 2, repo: 3 },
+    { regex: /^ssh:\/\/git@vs-ssh\.visualstudio\.com(?::\d+)?\/DefaultCollection\/([^/]+)\/_ssh\/([^/?#]+)(?:[/?#].*)?$/i, project: 1, repo: 2 },
+  ]
+  for (const pattern of patterns) {
+    const match = normalized.match(pattern.regex)
+    if (match) {
+      return {
+        remoteName: 'origin',
+        project: pattern.project === null ? null : decodeURIComponent(match[pattern.project] ?? ''),
+        repo: decodeURIComponent(match[pattern.repo] ?? ''),
+        remoteUrl,
+      }
+    }
+  }
+  return null
+}

--- a/apps/desktop/src/main/git-parsers.ts
+++ b/apps/desktop/src/main/git-parsers.ts
@@ -1,0 +1,80 @@
+import type { CommitLogEntry } from '../shared/types'
+import type { GitFileChange } from './git'
+
+const FILE_STATUSES = ['M', 'A', 'D', 'R', 'U', '?'] as const
+
+function isFileStatus(value: string): value is GitFileChange['status'] {
+  return FILE_STATUSES.includes(value as GitFileChange['status'])
+}
+
+export function parseNameStatus(output: string): GitFileChange[] {
+  if (!output) return []
+  const files: GitFileChange[] = []
+  for (const line of output.split(/\r?\n/).filter(Boolean)) {
+    const parts = line.split('\t')
+    const status = parts[0]?.[0] ?? ''
+    if (!isFileStatus(status)) continue
+    if (status === 'R') {
+      const oldPath = parts[1]
+      const newPath = parts[2]
+      if (newPath) files.push({ status, path: newPath, oldPath, staged: false })
+      continue
+    }
+    const path = parts[1]
+    if (path) files.push({ status, path, staged: false })
+  }
+  return files
+}
+
+export function parsePorcelainStatus(output: string): GitFileChange[] {
+  const files: GitFileChange[] = []
+  for (const line of output.split(/\r?\n/).filter(Boolean)) {
+    if (line.length < 4) continue
+    const stagedCode = line[0] ?? ''
+    const unstagedCode = line[1] ?? ''
+    const rest = line.slice(3).trimEnd()
+
+    if (stagedCode === 'R' || unstagedCode === 'R') {
+      const arrowIndex = rest.indexOf(' -> ')
+      files.push({
+        status: 'R',
+        path: arrowIndex === -1 ? rest : rest.slice(arrowIndex + 4),
+        oldPath: arrowIndex === -1 ? '' : rest.slice(0, arrowIndex),
+        staged: stagedCode === 'R',
+      })
+      continue
+    }
+
+    if (isFileStatus(stagedCode) && stagedCode !== '?') {
+      files.push({ status: stagedCode, path: rest, staged: true })
+    }
+    if (isFileStatus(unstagedCode) && unstagedCode !== '?') {
+      files.push({ status: unstagedCode, path: rest, staged: false })
+    }
+    if (stagedCode === '?' && unstagedCode === '?') {
+      files.push({ status: '?', path: rest, staged: false })
+    }
+  }
+  return files
+}
+
+export function parseCommitLog(output: string): CommitLogEntry[] {
+  if (!output) return []
+  const entries: CommitLogEntry[] = []
+  for (const line of output.split(/\r?\n/)) {
+    if (!line) continue
+    const parts = line.split('\t')
+    if (parts.length < 7) continue
+    const [sha, shortSha, authorName, authorEmail, authorDate, parentsRaw, ...subjectRest] = parts
+    entries.push({
+      sha,
+      shortSha,
+      authorName,
+      authorEmail,
+      authorDate,
+      parents: parentsRaw ? parentsRaw.split(/\s+/).filter(Boolean) : [],
+      subject: subjectRest.join('\t'),
+    })
+  }
+  return entries
+}

--- a/apps/desktop/src/main/git-runner.ts
+++ b/apps/desktop/src/main/git-runner.ts
@@ -1,0 +1,86 @@
+import type { Runner } from './driver/runner'
+
+const GIT_LOCK_MAX_ATTEMPTS = 10
+const GIT_MAX_OUTPUT_BYTES = 4 * 1024 * 1024
+
+export class GitLockedError extends Error {
+  readonly code = 'GIT_LOCKED' as const
+  readonly lockPath: string | null
+
+  constructor(message: string, lockPath: string | null) {
+    super(message)
+    this.name = 'GitLockedError'
+    this.lockPath = lockPath
+  }
+}
+
+export class GitCommandError extends Error {
+  readonly stdout: string
+  readonly stderr: string
+  readonly exitCode: number | null
+
+  constructor(message: string, stdout: string, stderr: string, exitCode: number | null) {
+    super(message)
+    this.name = 'GitCommandError'
+    this.stdout = stdout
+    this.stderr = stderr
+    this.exitCode = exitCode
+  }
+}
+
+export function extractLockPathFromStderr(stderr: string): string | null {
+  if (!stderr) return null
+  if (!/index\.lock|Another git process seems to be running|cannot lock ref|Unable to create .*\.lock/i.test(stderr)) {
+    return null
+  }
+  const quoted = stderr.match(/Unable to create\s+'([^']+\.lock)'/i) || stderr.match(/'([^']+\.lock)'/i)
+  if (quoted) return quoted[1]
+  if (/Another git process seems to be running/i.test(stderr)) return 'index.lock'
+  const bare = stderr.match(/([^\s'"`]+\.lock)\b/i)
+  return bare ? bare[1] : null
+}
+
+export interface RunGitOptions {
+  maxAttempts?: number
+  delay?: (milliseconds: number) => Promise<void>
+}
+
+export async function runGit(
+  runner: Runner,
+  workDir: string,
+  args: string[],
+  options: RunGitOptions = {},
+): Promise<string> {
+  const maxAttempts = options.maxAttempts ?? GIT_LOCK_MAX_ATTEMPTS
+  const delay = options.delay ?? ((milliseconds: number) => new Promise<void>((resolve) => setTimeout(resolve, milliseconds)))
+  let lastLockPath: string | null = null
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const result = await runner.run({
+      binary: 'git',
+      args,
+      workDir,
+      maxOutputBytes: GIT_MAX_OUTPUT_BYTES,
+    })
+    if (result.exitCode === 0) return result.stdout.trimEnd()
+
+    const lockPath = extractLockPathFromStderr(result.stderr)
+      ?? extractLockPathFromStderr(result.stdout)
+    if (lockPath === null) {
+      throw new GitCommandError(
+        result.stderr.trim() || `git exited with code ${result.exitCode}`,
+        result.stdout,
+        result.stderr,
+        result.exitCode,
+      )
+    }
+
+    lastLockPath = lockPath
+    if (attempt < maxAttempts) await delay(Math.pow(attempt, 2) * 50)
+  }
+
+  throw new GitLockedError(
+    `Git repository is locked${lastLockPath ? ` (${lastLockPath})` : ''}. Another git process may be running, or a previous one crashed and left a stale lock.`,
+    lastLockPath,
+  )
+}

--- a/apps/desktop/src/main/git.ts
+++ b/apps/desktop/src/main/git.ts
@@ -1,5 +1,3 @@
-import { execFile } from 'child_process'
-import { promisify } from 'util'
 import { promises as fsPromises, Dirent } from 'fs'
 import * as path from 'path'
 import {
@@ -15,10 +13,13 @@ import {
   generatePullRequestText as generatePullRequestTextFromModel,
 } from './git-text-model'
 import { SshConfig, WslConfig, GitBranches, LastCommitInfo, StashEntry, PullResult, CommitLogEntry } from '../shared/types'
+import { createRunner } from './driver/runner'
+import { runGit } from './git-runner'
+import { parseCommitLog, parseNameStatus, parsePorcelainStatus } from './git-parsers'
 import { sshExec } from './ssh'
 import { wslExec } from './wsl'
 
-const execFileAsync = promisify(execFile)
+export { GitLockedError } from './git-runner'
 
 type CachePolicy = {
   ttlMs: number
@@ -132,102 +133,12 @@ export interface GitStatus {
 
 export type GitHostingProvider = 'azure' | 'github'
 
-function parseNameStatus(output: string): GitFileChange[] {
-  if (!output) return []
-  const files: GitFileChange[] = []
-  const lines = output.split(/\r?\n/).filter(Boolean)
-  for (const line of lines) {
-    const parts = line.split('\t')
-    const rawStatus = parts[0] ?? ''
-    const status = rawStatus[0]
-    if (!status || !['M', 'A', 'D', 'R', 'U', '?'].includes(status)) continue
-    if (status === 'R') {
-      const oldPath = parts[1]
-      const newPath = parts[2]
-      if (!newPath) continue
-      files.push({ status: 'R', path: newPath, oldPath, staged: false })
-      continue
-    }
-    const path = parts[1]
-    if (!path) continue
-    files.push({ status: status as GitFileChange['status'], path, staged: false })
-  }
-  return files
-}
-
-/**
- * Error thrown when git repeatedly fails because another process holds the repo lock.
- * The `lockPath` (when known) points at the offending `.git/*.lock` file so the UI can
- * offer a "Force Unlock" action. Inspired by VS Code's `RepositoryIsLocked` error code.
- */
-export class GitLockedError extends Error {
-  code = 'GIT_LOCKED' as const
-  lockPath: string | null
-  constructor(message: string, lockPath: string | null = null) {
-    super(message)
-    this.name = 'GitLockedError'
-    this.lockPath = lockPath
-  }
-}
-
-/**
- * Pattern-match git stderr for lock-contention errors. Covers the three common flavours:
- *  - `fatal: Unable to create '<repo>/.git/index.lock': File exists.`
- *  - `Another git process seems to be running in this repository, e.g. an editor …`
- *  - `fatal: cannot lock ref 'refs/heads/foo': Unable to create '<…>/foo.lock': File exists.`
- */
-function extractLockPathFromStderr(stderr: string): string | null {
-  if (!stderr) return null
-  if (!/index\.lock|Another git process seems to be running|cannot lock ref|Unable to create .*\.lock/i.test(stderr)) {
-    return null
-  }
-  // Prefer the exact lock path when git names it (quoted form is most reliable).
-  const quoted = stderr.match(/Unable to create\s+'([^']+\.lock)'/i) || stderr.match(/'([^']+\.lock)'/i)
-  if (quoted) return quoted[1]
-  if (/Another git process seems to be running/i.test(stderr)) return 'index.lock'
-  const bare = stderr.match(/([^\s'"`]+\.lock)\b/i)
-  return bare ? bare[1] : null
-}
-
-/** True if the error thrown by one of the transport-specific git execs looks like a lock-contention failure. */
-function isLockError(err: unknown): { locked: true; lockPath: string | null } | null {
-  const stderr = (err as { stderr?: string } | null)?.stderr ?? ''
-  const message = (err instanceof Error ? err.message : String(err ?? '')) ?? ''
-  const lockPath = extractLockPathFromStderr(stderr) ?? extractLockPathFromStderr(message)
-  return lockPath !== null ? { locked: true, lockPath } : null
-}
-
-const GIT_LOCK_MAX_ATTEMPTS = 10
 const GENERATED_TEXT_CACHE_TTL_MS = 5 * 60_000
 const UNTRACKED_FILE_PREVIEW_BYTES = 16_000
 const UNTRACKED_PATCH_MAX_CHARS = 30_000
 
 async function git(cwd: string, args: string[], ssh?: SshConfig | null, wsl?: WslConfig | null): Promise<string> {
-  const gitCmd = `git ${args.map(a => "'" + a.replace(/'/g, "'\\''") + "'").join(' ')}`
-
-  // Retry on lock contention with VS Code-style quadratic backoff: 50ms, 200ms, 450ms, …, ~5s.
-  // This transparently rides out races between concurrent Claude sessions, the user's editor,
-  // and other tooling all touching the same repo at once.
-  let lastLockPath: string | null = null
-  for (let attempt = 1; attempt <= GIT_LOCK_MAX_ATTEMPTS; attempt++) {
-    try {
-      if (ssh) return await sshExec(ssh, cwd, gitCmd)
-      if (wsl) return await wslExec(wsl, cwd, gitCmd)
-      const { stdout } = await execFileAsync('git', args, { cwd, maxBuffer: 4 * 1024 * 1024 })
-      return stdout.trimEnd()
-    } catch (err) {
-      const lock = isLockError(err)
-      if (!lock) throw err
-      lastLockPath = lock.lockPath
-      if (attempt === GIT_LOCK_MAX_ATTEMPTS) break
-      const delayMs = Math.pow(attempt, 2) * 50
-      await new Promise((resolve) => setTimeout(resolve, delayMs))
-    }
-  }
-  throw new GitLockedError(
-    `Git repository is locked${lastLockPath ? ` (${lastLockPath})` : ''}. Another git process may be running, or a previous one crashed and left a stale lock.`,
-    lastLockPath,
-  )
+  return runGit(createRunner({ ssh: ssh ?? undefined, wsl: wsl ?? undefined }), cwd, args)
 }
 
 /**
@@ -271,7 +182,7 @@ export async function forceUnlockRepo(
   }
 
   // Local: resolve `.git` via git itself (works with worktrees and submodules), then unlink files directly.
-  const gitDirRel = (await execFileAsync('git', ['rev-parse', '--git-dir'], { cwd: repoPath, maxBuffer: 1024 * 1024 })).stdout.trim()
+  const gitDirRel = (await git(repoPath, ['rev-parse', '--git-dir'])).trim()
   const gitDir = path.isAbsolute(gitDirRel) ? gitDirRel : path.join(repoPath, gitDirRel)
   const removed: string[] = []
 
@@ -410,40 +321,7 @@ export async function getGitStatus(repoPath: string, ssh?: SshConfig | null, wsl
       console.error(`[git:status] porcelain failed (${via}) for ${repoPath}:`, err)
     }
 
-    const files: GitFileChange[] = []
-    if (porcelain) {
-      const lines = porcelain.split(/\r?\n/).filter(Boolean)
-      for (const line of lines) {
-        if (line.length < 4) continue
-        const stagedCode = line[0]!
-        const unstagedCode = line[1]!
-        const rest = line.slice(3).trimEnd() // skip "XY ", strip Windows CR
-
-        const isRename = stagedCode === 'R' || unstagedCode === 'R'
-
-        if (isRename) {
-          // Format: "R  ORIG_PATH -> NEW_PATH"
-          const arrowIdx = rest.indexOf(' -> ')
-          const newPath = arrowIdx !== -1 ? rest.slice(arrowIdx + 4) : rest
-          const oldPath = arrowIdx !== -1 ? rest.slice(0, arrowIdx) : ''
-          files.push({ status: 'R', path: newPath, oldPath, staged: stagedCode === 'R' })
-        } else {
-          const filePath = rest
-          // Staged change
-          if (stagedCode !== ' ' && stagedCode !== '?') {
-            files.push({ status: stagedCode as GitFileChange['status'], path: filePath, staged: true })
-          }
-          // Unstaged change
-          if (unstagedCode !== ' ' && unstagedCode !== '?') {
-            files.push({ status: unstagedCode as GitFileChange['status'], path: filePath, staged: false })
-          }
-          // Untracked
-          if (stagedCode === '?' && unstagedCode === '?') {
-            files.push({ status: '?', path: filePath, staged: false })
-          }
-        }
-      }
-    }
+    const files = parsePorcelainStatus(porcelain)
 
     // Diff stats (staged + unstaged combined)
     let additions = 0
@@ -1078,22 +956,6 @@ export async function getFileDiff(repoPath: string, filePath: string, staged: bo
  *   %ae author email     %aI ISO date      %P  parents (space-separated)
  *   %s  subject (single line — git never emits newlines in %s)
  */
-function parseCommitLog(output: string): CommitLogEntry[] {
-  if (!output) return []
-  const entries: CommitLogEntry[] = []
-  for (const line of output.split(/\r?\n/)) {
-    if (!line) continue
-    // Split with limit so any stray TABs in subject don't break the record (they shouldn't exist, but belt-and-braces).
-    const parts = line.split('\t')
-    if (parts.length < 7) continue
-    const [sha, shortSha, authorName, authorEmail, authorDate, parentsRaw, ...subjectRest] = parts
-    const subject = subjectRest.join('\t')
-    const parents = parentsRaw ? parentsRaw.split(/\s+/).filter(Boolean) : []
-    entries.push({ sha, shortSha, authorName, authorEmail, authorDate, parents, subject })
-  }
-  return entries
-}
-
 /**
  * List commits reachable from `opts.range` (default `HEAD`) in chronological (newest-first) order.
  * Pass a range like `"origin/main..HEAD"` to limit to commits on the current branch not yet on base.
@@ -1644,7 +1506,7 @@ export async function mergeBranch(repoPath: string, source: string, ssh?: SshCon
     await git(repoPath, ['merge', source], ssh, wsl)
     return { conflicts: [] }
   } catch (err: unknown) {
-    // execFileAsync (local) attaches stdout to the error; SSH/WSL errors carry it in the message
+    // Runner errors retain stderr separately so callers can distinguish an invalid range.
     const output: string = (err as { stdout?: string; message?: string }).stdout ?? (err instanceof Error ? err.message : '') ?? ''
     if (output.includes('CONFLICT') || output.includes('Automatic merge failed')) {
       const conflicts: string[] = []

--- a/apps/desktop/src/main/github.ts
+++ b/apps/desktop/src/main/github.ts
@@ -1,15 +1,12 @@
-import { execFile, spawn } from 'child_process'
-import { promisify } from 'util'
 import { promises as fsPromises } from 'fs'
 import { tmpdir } from 'os'
 import * as path from 'path'
 import { randomUUID } from 'crypto'
 import { GitHubPullRequest, SshConfig, WslConfig } from '../shared/types'
-import { augmentWindowsPath, winQuote } from './driver/runner'
-import { sshExec } from './ssh'
-import { wslExec } from './wsl'
-
-const execFileAsync = promisify(execFile)
+import { createRunner } from './driver/runner'
+import { runGit } from './git-runner'
+import { mapGitHubPr as mapPr, parseGitHubRemote } from './forge-parsers'
+import type { GitHubPrInput as GhPullRequest } from './forge-parsers'
 
 interface GitHubRepoContext {
   remoteName: string
@@ -17,121 +14,20 @@ interface GitHubRepoContext {
   repo: string
 }
 
-interface GhAuthor {
-  login?: string
-  name?: string
-}
-
-interface GhPullRequest {
-  number?: number
-  title?: string
-  state?: string
-  headRefName?: string
-  baseRefName?: string
-  author?: GhAuthor
-  url?: string
-  createdAt?: string
-}
-
-interface SpawnResult {
-  stdout: string
-  stderr: string
-  code: number | null
-}
-
-function mapPr(pr: GhPullRequest): GitHubPullRequest {
-  const statusRaw = pr.state ?? 'UNKNOWN'
-  return {
-    id: pr.number ?? 0,
-    title: pr.title ?? '(untitled)',
-    status: statusRaw.toLowerCase(),
-    sourceBranch: pr.headRefName ?? '',
-    targetBranch: pr.baseRefName ?? '',
-    authorName: pr.author?.name ?? pr.author?.login ?? 'Unknown',
-    url: pr.url ?? '',
-    creationDate: pr.createdAt ?? '',
-  }
-}
-
-function parseGitHubRemote(remoteUrl: string): Omit<GitHubRepoContext, 'remoteName'> | null {
-  const normalized = remoteUrl.replace(/\.git$/i, '')
-
-  const https = normalized.match(/^https:\/\/(?:[^@/]+@)?github\.com\/([^/]+)\/([^/?#]+)(?:[/?#].*)?$/i)
-  if (https) {
-    return {
-      owner: decodeURIComponent(https[1] ?? ''),
-      repo: decodeURIComponent(https[2] ?? ''),
-    }
-  }
-
-  const ssh = normalized.match(/^git@github\.com:([^/]+)\/([^/?#]+)(?:[/?#].*)?$/i)
-  if (ssh) {
-    return {
-      owner: decodeURIComponent(ssh[1] ?? ''),
-      repo: decodeURIComponent(ssh[2] ?? ''),
-    }
-  }
-
-  const sshUrl = normalized.match(/^ssh:\/\/git@github\.com\/([^/]+)\/([^/?#]+)(?:[/?#].*)?$/i)
-  if (sshUrl) {
-    return {
-      owner: decodeURIComponent(sshUrl[1] ?? ''),
-      repo: decodeURIComponent(sshUrl[2] ?? ''),
-    }
-  }
-
-  return null
-}
-
-async function runLocal(cmd: string, args: string[], cwd: string): Promise<SpawnResult> {
-  return new Promise((resolve) => {
-    const isWindows = process.platform === 'win32'
-    const proc = isWindows
-      ? spawn([cmd, ...args.map(winQuote)].join(' '), [], {
-        cwd,
-        shell: true,
-        env: augmentWindowsPath(),
-        stdio: ['ignore', 'pipe', 'pipe'],
-      })
-      : spawn(cmd, args, {
-        cwd,
-        shell: false,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      })
-
-    let stdout = ''
-    let stderr = ''
-
-    proc.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8') })
-    proc.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8') })
-
-    proc.on('close', (code) => resolve({ stdout: stdout.trim(), stderr: stderr.trim(), code }))
-    proc.on('error', (err) => resolve({ stdout: '', stderr: err.message, code: null }))
-  })
-}
-
 async function git(repoPath: string, args: string[], ssh?: SshConfig | null, wsl?: WslConfig | null): Promise<string> {
-  const gitCmd = `git ${args.map(a => "'" + a.replace(/'/g, "'\\''") + "'").join(' ')}`
-  if (ssh) return sshExec(ssh, repoPath, gitCmd)
-  if (wsl) return wslExec(wsl, repoPath, gitCmd)
-  const { stdout } = await execFileAsync('git', args, { cwd: repoPath, maxBuffer: 4 * 1024 * 1024 })
-  return stdout.trimEnd()
+  return runGit(createRunner({ ssh: ssh ?? undefined, wsl: wsl ?? undefined }), repoPath, args)
 }
 
 async function runGh(repoPath: string, args: string[], ssh?: SshConfig | null, wsl?: WslConfig | null): Promise<string> {
-  const quoted = args.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(' ')
-
-  if (ssh) return (await sshExec(ssh, repoPath, `gh ${quoted}`)).trim()
-  if (wsl) return (await wslExec(wsl, repoPath, `gh ${quoted}`)).trim()
-
-  const result = await runLocal('gh', args, repoPath)
-  if (result.code !== 0) {
+  const runner = createRunner({ ssh: ssh ?? undefined, wsl: wsl ?? undefined })
+  const result = await runner.run({ binary: 'gh', args, workDir: repoPath })
+  if (result.exitCode !== 0) {
     if (/ENOENT|EINVAL|not found|is not recognized/i.test(result.stderr)) {
       throw new Error('gh CLI not found. Install and authenticate it first (gh auth login).')
     }
     throw new Error(result.stderr || 'Failed to execute gh CLI')
   }
-  return result.stdout
+  return result.stdout.trim()
 }
 
 async function resolveRepoContext(repoPath: string, ssh?: SshConfig | null, wsl?: WslConfig | null): Promise<GitHubRepoContext> {

--- a/apps/desktop/src/main/project-admin.ts
+++ b/apps/desktop/src/main/project-admin.ts
@@ -2,7 +2,6 @@
  * Project and location provisioning logic shared by the local IPC handlers
  * and the remote-control RPC surface (extracted from ipc/handlers.ts).
  */
-import { spawn } from 'child_process'
 import { existsSync, mkdirSync, rmSync } from 'fs'
 import { homedir } from 'os'
 import { basename, dirname, join } from 'path'
@@ -19,6 +18,8 @@ import {
   listCommands,
 } from './db/queries'
 import { gitInit, getRemoteUrl } from './git'
+import { createRunner } from './driver/runner'
+import { runGit as executeGit } from './git-runner'
 import { sessionManager } from './session/manager'
 import { commandManager } from './commands/manager'
 import { NewProjectResult, NewProjectSpec, RepoLocation } from '../shared/types'
@@ -44,31 +45,10 @@ export function suggestUniquePath(baseDir: string, name: string): string {
 }
 
 /** Run `git clone <gitUrl> <clonePath>`, creating the parent directory first. */
-export function cloneRepo(gitUrl: string, clonePath: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    try {
-      mkdirSync(join(clonePath, '..'), { recursive: true })
-    } catch {
-      // parent may already exist
-    }
-
-    const proc = spawn('git', ['clone', gitUrl, clonePath], {
-      shell: false,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    })
-
-    let stderr = ''
-    proc.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString() })
-
-    proc.on('close', (code) => {
-      if (code === 0) resolve()
-      else reject(new Error(stderr.trim() || `git clone exited with code ${code}`))
-    })
-
-    proc.on('error', (err) => {
-      reject(new Error(`Failed to run git: ${err.message}`))
-    })
-  })
+export async function cloneRepo(gitUrl: string, clonePath: string): Promise<void> {
+  const parentDir = join(clonePath, '..')
+  mkdirSync(parentDir, { recursive: true })
+  await executeGit(createRunner({}), parentDir, ['clone', gitUrl, clonePath])
 }
 
 function sanitizeWorktreeSegment(value: string): string {
@@ -77,25 +57,7 @@ function sanitizeWorktreeSegment(value: string): string {
 }
 
 function runGit(args: string[], cwd: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const proc = spawn('git', args, {
-      cwd,
-      shell: false,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    })
-    let stdout = ''
-    let stderr = ''
-    proc.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString() })
-    proc.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString() })
-    proc.on('close', (code) => {
-      if (code === 0) {
-        resolve(stdout)
-        return
-      }
-      reject(new Error(stderr.trim() || `git exited with code ${code}`))
-    })
-    proc.on('error', (err) => reject(new Error(`Failed to run git: ${err.message}`)))
-  })
+  return executeGit(createRunner({}), cwd, args)
 }
 
 async function resolveWorktreeBaseRef(repoPath: string): Promise<string> {


### PR DESCRIPTION
## What changed

- add `Runner.run()` for collect-and-await process execution, including timeout and bounded output
- add a `FakeRunner` adapter that records semantic commands for tests
- centralize Git execution, lock detection, quadratic retry, and typed errors in `runGit()`
- route Git, GitHub CLI, Azure DevOps CLI, and project administration Git calls through Runner
- preserve Windows `azdevops.cmd` resolution
- extract and characterize Git and forge parsers

## Why

The main process had several independent local/WSL/SSH process implementations alongside an existing, tested Runner seam. The duplicated Git implementations had also dropped the repository-lock retry used by `git.ts`, causing fetch and checkout operations to fail immediately under transient lock contention.

This deepens the Runner module, restores one Git execution policy across the migrated callers, and introduces a test adapter for later migrations.

## Impact

Git operations from the GitHub, Azure DevOps, and project administration paths now receive the same lock retry behavior as the main Git module. Platform-specific command construction stays inside Runner adapters, while callers issue semantic commands.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 277 passed, 15 environment-dependent tests skipped
- `git diff --check`
