### PR TITLE
Use opaque worktree branches and await command cleanup

### DIFF
--- a/apps/desktop/src/main/__tests__/commands-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/commands-manager.test.ts
@@ -55,6 +55,25 @@ function fakeRunner(type: 'local' | 'wsl' | 'ssh'): FakeRunner {
   return runner
 }
 
+function activeFakeRunner(type: 'local' | 'wsl' | 'ssh'): { runner: FakeRunner; proc: ChildProcess } {
+  const runner = new FakeRunner(type)
+  const emitter = new EventEmitter()
+  const proc = Object.assign(emitter, {
+    pid: 4321,
+    exitCode: null,
+    signalCode: null,
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    kill: vi.fn(() => true),
+  }) as unknown as ChildProcess
+  runner.spawnScript = ((cmd) => {
+    runner.spawnedScripts.push(cmd)
+    return proc
+  }) as FakeRunner['spawnScript']
+  createRunnerMock.mockReturnValue(runner)
+  return { runner, proc }
+}
+
 async function loadManager(): Promise<typeof import('../commands/manager')> {
   vi.resetModules()
   return import('../commands/manager')
@@ -203,5 +222,45 @@ describe('CommandManager.start — shell and working directory', () => {
     await commandManager.start('c1', 'l1')
 
     expect(runner.spawnedScripts[0].workDir).toBe('/srv/app/packages/api')
+  })
+})
+
+describe('CommandManager cleanup', () => {
+  it('lets callers await all commands at a location exiting', async () => {
+    givenCommand('npm run dev')
+    getLocationById.mockReturnValue({ id: 'l1', connection_type: 'local', path: process.cwd() })
+    const { proc } = activeFakeRunner('local')
+    const { commandManager } = await loadManager()
+    await commandManager.start('c1', 'l1')
+
+    let settled = false
+    const stopped = commandManager.stopAllForLocation('l1').then(() => { settled = true })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    Object.assign(proc, { exitCode: 0 })
+    proc.emit('close', 0)
+    await stopped
+
+    expect(commandManager.getStatus('c1', 'l1')).toBe('stopped')
+  })
+
+  it('lets app shutdown await every command exiting', async () => {
+    givenCommand('npm run dev')
+    getLocationById.mockReturnValue({ id: 'l1', connection_type: 'local', path: process.cwd() })
+    const { proc } = activeFakeRunner('local')
+    const { commandManager } = await loadManager()
+    await commandManager.start('c1', 'l1')
+
+    let settled = false
+    const stopped = commandManager.stopAll().then(() => { settled = true })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    Object.assign(proc, { exitCode: 0 })
+    proc.emit('close', 0)
+    await stopped
+
+    expect(commandManager.hasRunning()).toBe(false)
   })
 })

--- a/apps/desktop/src/main/__tests__/project-admin.test.ts
+++ b/apps/desktop/src/main/__tests__/project-admin.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'vitest'
-import { isWorktreeDirectoryCleanupError, parseGitWorktreeList } from '../project-admin'
+import {
+  createWorktreeBranchName,
+  isWorktreeDirectoryCleanupError,
+  parseGitWorktreeList,
+} from '../project-admin'
+
+describe('createWorktreeBranchName', () => {
+  it('uses only the opaque worktree id under the polycode namespace', () => {
+    expect(createWorktreeBranchName(1_234_567_890)).toBe('polycode/kf12oi')
+  })
+})
 
 describe('parseGitWorktreeList', () => {
   it('parses normal and prunable records from nul-delimited porcelain output', () => {

--- a/apps/desktop/src/main/commands/manager.ts
+++ b/apps/desktop/src/main/commands/manager.ts
@@ -338,12 +338,25 @@ class CommandManager {
   }
 
   /** Stop all running instances for a given commandId (used when deleting a command). */
-  stopAllInstances(commandId: string): void {
+  async stopAllInstances(commandId: string): Promise<void> {
+    const stops: Promise<void>[] = []
     for (const entry of this.running.values()) {
       if (entry.commandId === commandId) {
-        void this.stop(commandId, entry.locationId)
+        stops.push(this.stop(commandId, entry.locationId))
       }
     }
+    await Promise.all(stops)
+  }
+
+  /** Stop every project command running at a location before that location is removed. */
+  async stopAllForLocation(locationId: string): Promise<void> {
+    const stops: Promise<void>[] = []
+    for (const entry of this.running.values()) {
+      if (entry.locationId === locationId) {
+        stops.push(this.stop(entry.commandId, locationId))
+      }
+    }
+    await Promise.all(stops)
   }
 
   hasRunning(): boolean {
@@ -353,10 +366,12 @@ class CommandManager {
     return false
   }
 
-  stopAll(): void {
+  async stopAll(): Promise<void> {
+    const stops: Promise<void>[] = []
     for (const entry of [...this.running.values()]) {
-      void this.stop(entry.commandId, entry.locationId)
+      stops.push(this.stop(entry.commandId, entry.locationId))
     }
+    await Promise.all(stops)
   }
 
   /** Get statuses for all commands of a project at a given location. */

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -190,7 +190,7 @@ function createWindow(): BrowserWindow {
       if (response !== 0) return
 
       sessionManager.stopAll()
-      commandManager.stopAll()
+      await commandManager.stopAll()
       isQuitting = true
       win.close()
     }
@@ -280,11 +280,18 @@ app.on('window-all-closed', () => {
   }
 })
 
-app.on('before-quit', () => {
+let commandShutdown: Promise<void> | null = null
+
+app.on('before-quit', (event) => {
+  if (!commandShutdown) {
+    event.preventDefault()
+    commandShutdown = commandManager.stopAll().finally(() => app.quit())
+    return
+  }
+
   isQuitting = true
   runLifecycle?.stop()
   sessionManager.stopAll()
-  commandManager.stopAll()
   stopWebhookServer()
   stopRemoteControlClient()
   stopRemoteControlServer()

--- a/apps/desktop/src/main/ipc/channel-handlers.ts
+++ b/apps/desktop/src/main/ipc/channel-handlers.ts
@@ -632,8 +632,8 @@ export const channelHandlers = {
   'commands:update': (_ctx, id, name, command, cwd, shell, runOnWorktreeCreate) =>
     updateCommand(id, name, command, cwd, shell, runOnWorktreeCreate ?? false),
 
-  'commands:delete': (_ctx, id) => {
-    commandManager.stopAllInstances(id)
+  'commands:delete': async (_ctx, id) => {
+    await commandManager.stopAllInstances(id)
     return deleteCommand(id)
   },
 

--- a/apps/desktop/src/main/project-admin.ts
+++ b/apps/desktop/src/main/project-admin.ts
@@ -264,6 +264,7 @@ export async function removeWorktreeLocation(id: string): Promise<void> {
   if (!location) return
   if (!location.is_worktree) throw new Error('Location is not a worktree.')
   if (location.connection_type !== 'local') throw new Error('Worktree removal is currently supported for local locations only.')
+  await commandManager.stopAllForLocation(location.id)
   for (const thread of listActiveThreadsForLocation(location.id)) {
     sessionManager.remove(thread.id)
     if (thread.has_messages) {

--- a/apps/desktop/src/main/project-admin.ts
+++ b/apps/desktop/src/main/project-admin.ts
@@ -57,6 +57,11 @@ function sanitizeWorktreeSegment(value: string): string {
   return cleaned || `worktree-${Date.now()}`
 }
 
+/** Worktree branches are intentionally opaque: their label does not describe their base. */
+export function createWorktreeBranchName(timestamp: number = Date.now()): string {
+  return `polycode/${timestamp.toString(36)}`
+}
+
 function runGit(args: string[], cwd: string): Promise<string> {
   return executeGit(createRunner({}), cwd, args)
 }
@@ -246,7 +251,7 @@ export async function createLocalWorktree(parentLocationId: string, label?: stri
     suffix += 1
   }
 
-  const branchName = `polycode/${baseName}-${Date.now().toString(36)}`
+  const branchName = createWorktreeBranchName()
   const baseRef = baseRefOverride ?? await resolveWorktreeBaseRef(parent.path)
   await runGit(['worktree', 'add', '-b', branchName, worktreePath, baseRef], parent.path)
   const location = createWorktreeLocation(parent, label?.trim() || baseName, worktreePath)


### PR DESCRIPTION
## Summary
- Generate opaque `polycode/<id>` branch names for new worktrees.
- Await command termination before deleting commands or removing worktree locations.
- Make application shutdown wait for all running commands to exit.
- Add coverage for opaque branch names and asynchronous cleanup behavior.