### PR TITLE
Guard renderer events during shutdown

### DIFF
--- a/apps/desktop/src/main/__tests__/app-events.test.ts
+++ b/apps/desktop/src/main/__tests__/app-events.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { BrowserWindow } from 'electron'
+import { emitAppEvent, onAppEvent } from '../app-events'
+
+function fakeWindow(options: { windowDestroyed?: boolean; webContentsDestroyed?: boolean } = {}) {
+  const destroyed = options.windowDestroyed || options.webContentsDestroyed
+  const send = vi.fn(() => {
+    if (destroyed) throw new TypeError('Object has been destroyed')
+  })
+  const window = {
+    isDestroyed: () => options.windowDestroyed ?? false,
+    webContents: {
+      isDestroyed: () => options.webContentsDestroyed ?? false,
+      send,
+    },
+  } as unknown as BrowserWindow
+
+  return { window, send }
+}
+
+describe('emitAppEvent', () => {
+  it('sends to the renderer and publishes to the in-process event bus', () => {
+    const { window, send } = fakeWindow()
+    const listener = vi.fn()
+    const unsubscribe = onAppEvent(listener)
+
+    expect(() => emitAppEvent(window, 'test:event', 'payload')).not.toThrow()
+
+    expect(send).toHaveBeenCalledWith('test:event', 'payload')
+    expect(listener).toHaveBeenCalledWith({ channel: 'test:event', args: ['payload'] })
+    unsubscribe()
+  })
+
+  it.each([
+    ['window', { windowDestroyed: true }],
+    ['webContents', { webContentsDestroyed: true }],
+  ])('does not send when the %s has been destroyed, but still publishes in-process', (_name, options) => {
+    const { window, send } = fakeWindow(options)
+    const listener = vi.fn()
+    const unsubscribe = onAppEvent(listener)
+
+    expect(() => emitAppEvent(window, 'test:event', 'payload')).not.toThrow()
+
+    expect(send).not.toHaveBeenCalled()
+    expect(listener).toHaveBeenCalledWith({ channel: 'test:event', args: ['payload'] })
+    unsubscribe()
+  })
+})

--- a/apps/desktop/src/main/__tests__/dispatch-characterisation.test.ts
+++ b/apps/desktop/src/main/__tests__/dispatch-characterisation.test.ts
@@ -869,6 +869,7 @@ const window = {
   maximize: H.stub('window.maximize'),
   unmaximize: H.stub('window.unmaximize'),
   close: H.stub('window.close'),
+  isDestroyed: () => false,
   isMaximized: H.stub('window.isMaximized', () => H.state.isMaximized),
   webContents: {
     isDestroyed: () => false,

--- a/apps/desktop/src/main/app-events.ts
+++ b/apps/desktop/src/main/app-events.ts
@@ -12,8 +12,13 @@ const appEventBus = new EventEmitter()
 appEventBus.setMaxListeners(0)
 
 export function emitAppEvent(window: BrowserWindow, channel: string, ...args: unknown[]): void {
-  window.webContents.send(channel, ...args)
+  sendToRenderer(window, channel, ...args)
   appEventBus.emit('event', { channel, args } satisfies AppEvent)
+}
+
+export function sendToRenderer(window: BrowserWindow, channel: string, ...args: unknown[]): void {
+  if (window.isDestroyed() || window.webContents.isDestroyed()) return
+  window.webContents.send(channel, ...args)
 }
 
 export function onAppEvent(listener: AppEventListener): () => void {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -24,7 +24,7 @@ import { createRunGit } from './runs/adapters/git'
 import { createRunWorktrees } from './runs/adapters/worktrees'
 import { createRunSessions } from './runs/adapters/sessions'
 import { electronRunNotifier } from './runs/adapters/notifier'
-import { emitAppEvent } from './app-events'
+import { emitAppEvent, sendToRenderer } from './app-events'
 import { commandManager } from './commands/manager'
 import { flushAppLogs, installAppLogger, writeFatalLog, writeRendererLog } from './app-logger'
 import { installIpcProfiling, installMainThreadStallMonitor } from './perf'
@@ -218,8 +218,6 @@ function createWindow(): BrowserWindow {
       })
       if (response !== 0) return
 
-      sessionManager.stopAll()
-      await commandManager.stopAll()
       isQuitting = true
       win.close()
     }
@@ -239,8 +237,8 @@ function createWindow(): BrowserWindow {
     if (contents.getType() !== 'webview') return
     contents.setWindowOpenHandler(({ url }) => {
       const locationId = browserSessionManager.locationIdForSession(contents.session)
-      if (locationId && /^https?:\/\//i.test(url) && !win.isDestroyed()) {
-        win.webContents.send('browser:popup-request', locationId, url)
+      if (locationId && /^https?:\/\//i.test(url)) {
+        sendToRenderer(win, 'browser:popup-request', locationId, url)
       }
       return { action: 'deny' }
     })
@@ -320,24 +318,20 @@ app.whenReady().then(() => {
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
-    cleanupAllAttachments()
-    closeDb()
     app.quit()
   }
 })
 
-let commandShutdown: Promise<void> | null = null
+let shutdownStarted = false
+let shutdownComplete = false
 
 app.on('before-quit', (event) => {
-  if (!commandShutdown) {
-    event.preventDefault()
-    commandShutdown = Promise.allSettled([
-      commandManager.stopAll(),
-      shutdownObservability(),
-    ]).then(() => undefined).finally(() => app.quit())
-    return
-  }
+  if (shutdownComplete) return
 
+  event.preventDefault()
+  if (shutdownStarted) return
+
+  shutdownStarted = true
   isQuitting = true
   runLifecycle?.stop()
   sessionManager.stopAll()
@@ -348,7 +342,15 @@ app.on('before-quit', (event) => {
   stopPlanWatcher()
   stopAllFileWatches()
   ptyManager.killAll()
-  cleanupAllAttachments()
-  closeDb()
-  flushAppLogs()
+
+  void Promise.allSettled([
+    commandManager.stopAll(),
+    shutdownObservability(),
+  ]).finally(() => {
+    cleanupAllAttachments()
+    closeDb()
+    flushAppLogs()
+    shutdownComplete = true
+    app.quit()
+  })
 })

--- a/apps/desktop/src/main/ipc/channel-handlers.ts
+++ b/apps/desktop/src/main/ipc/channel-handlers.ts
@@ -204,7 +204,7 @@ import {
   suggestUniquePath,
 } from '../project-admin'
 import { projectFaviconDataUrl, projectFaviconOverrideDataUrl, storeProjectFaviconPath } from '../project-favicon'
-import { emitAppEvent } from '../app-events'
+import { emitAppEvent, sendToRenderer } from '../app-events'
 import {
   amendCommit,
   applyStash,
@@ -771,8 +771,8 @@ export const channelHandlers = {
     // left to pass through. Both pre-fold paths discarded it too.
     session.sendMessage(content, options)
 
-    if (ctx.origin === 'remote' && !ctx.window.webContents.isDestroyed()) {
-      ctx.window.webContents.send(`thread:output:${threadId}`, {
+    if (ctx.origin === 'remote') {
+      sendToRenderer(ctx.window, `thread:output:${threadId}`, {
         type: 'text',
         content,
         metadata: { role: 'user', source: 'remote_client' },

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -1,5 +1,6 @@
 import { basename } from 'path'
 import { ipcMain, BrowserWindow } from 'electron'
+import { sendToRenderer } from '../app-events'
 import { isLocalChannel, isRemoteChannel } from '@polycode/shared'
 import { commandManager } from '../commands/manager'
 import { ptyManager } from '../terminal/manager'
@@ -111,8 +112,8 @@ export function registerIpcHandlers(window: BrowserWindow, runLifecycle: RunLife
   // `window.api.on`, which CHANNEL_REGISTRY does not inventory. The four `window:*`
   // request/response channels this pairs with are folded.
 
-  window.on('maximize',   () => window.webContents.send('window:maximized-changed', true))
-  window.on('unmaximize', () => window.webContents.send('window:maximized-changed', false))
+  window.on('maximize',   () => sendToRenderer(window, 'window:maximized-changed', true))
+  window.on('unmaximize', () => sendToRenderer(window, 'window:maximized-changed', false))
 
   // ── Terminal (PTY) ──────────────────────────────────────────────────────────
   //

--- a/apps/desktop/src/main/remote/client.ts
+++ b/apps/desktop/src/main/remote/client.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto'
 import { BrowserWindow } from 'electron'
 import { isRemoteChannel } from '@polycode/shared'
 import { getSetting, setSetting } from '../db/queries'
-import { emitAppEvent } from '../app-events'
+import { emitAppEvent, sendToRenderer } from '../app-events'
 import {
   RemoteConnectionStatus,
   RemoteHost,
@@ -325,8 +325,7 @@ export class RemoteControlClient {
     try {
       const event = JSON.parse(dataLines.join('\n')) as { channel?: unknown; args?: unknown }
       if (typeof event.channel !== 'string' || !Array.isArray(event.args)) return
-      if (this.window.webContents.isDestroyed()) return
-      this.window.webContents.send(event.channel, ...event.args)
+      sendToRenderer(this.window, event.channel, ...event.args)
     } catch {
       // Ignore malformed frames from a stale or incompatible host.
     }

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import * as Sentry from '@sentry/electron/main'
 import type { UpdateState } from '../shared/types'
+import { sendToRenderer } from './app-events'
 
 const FIRST_CHECK_DELAY = 10_000 // 10 seconds after launch
 const UPDATE_CHECK_INTERVAL = 30 * 60 * 1000 // every 30 minutes
@@ -41,11 +42,8 @@ function isExpectedNetworkError(error: unknown): boolean {
 }
 
 function broadcast(): void {
-  try {
-    getWindow()?.webContents.send('update:state', { ...updateState })
-  } catch {
-    // Window may not be ready yet
-  }
+  const window = getWindow()
+  if (window) sendToRenderer(window, 'update:state', { ...updateState })
 }
 
 function setState(partial: Partial<UpdateState>): void {


### PR DESCRIPTION
## Summary
- make `sendToRenderer` the lifecycle-safe boundary for all main-to-renderer sends
- keep `emitAppEvent` publishing to the in-process event bus after renderer teardown
- mark shutdown as started before stopping producers, then close attachments and SQLite only after asynchronous command/telemetry teardown
- add destroyed-window and destroyed-webContents regression coverage

## Root cause
Long-lived command, PTY, session, updater, remote, and window callbacks retained a `BrowserWindow` reference after Electron had destroyed either the window or its `webContents`. A non-null reference was therefore not sufficient to make `webContents.send()` safe. Separately, `window-all-closed` could close SQLite before the `before-quit` producer teardown ran.

## Verification
- `pnpm --filter polycode-electron typecheck`
- `pnpm lint`
- `pnpm build`
- affected suite: 350 tests passed
- full suite: 962 tests passed; the Windows-only runner suite timed out in its existing `wsl.exe` discovery `beforeAll` hook (also reproducible serially)

Closes #21