### PR TITLE
Fix stale browser locations

### DIFF
--- a/apps/desktop/src/main/browser/manager.ts
+++ b/apps/desktop/src/main/browser/manager.ts
@@ -1,6 +1,6 @@
 import { session, Session } from 'electron'
 import { getLocationById } from '../db/queries'
-import type { RepoLocation, SshConfig, BrowserSessionConfig } from '../../shared/types'
+import type { RepoLocation, SshConfig, BrowserPrepareSessionResult } from '../../shared/types'
 import { browserPartitionFor, sshLabelFor } from '../../shared/browser'
 import { SshTunnelPool } from './port-forward'
 import { startBrowserProxy, BrowserProxy } from './proxy-server'
@@ -46,9 +46,9 @@ class BrowserSessionManager {
   /** Sessions already configured not to prompt the page for permissions. */
   private hardened = new WeakSet<Session>()
 
-  async prepareSession(locationId: string): Promise<BrowserSessionConfig> {
+  async prepareSession(locationId: string): Promise<BrowserPrepareSessionResult> {
     const location = getLocationById(locationId)
-    if (!location) throw new Error(`Location ${locationId} not found`)
+    if (!location) return { ok: false, code: 'LOCATION_NOT_FOUND' }
 
     const partition = browserPartitionFor(locationId)
     const guestSession = session.fromPartition(partition)
@@ -64,7 +64,7 @@ class BrowserSessionManager {
       await guestSession.setProxy({ mode: 'direct' })
       this.prepared.add(locationId)
       this.locationKeys.delete(locationId)
-      return { partition, proxied: false, sshLabel: null }
+      return { ok: true, session: { partition, proxied: false, sshLabel: null } }
     }
 
     const key = proxyKeyFor(ssh)
@@ -83,7 +83,7 @@ class BrowserSessionManager {
       proxyRules: `http=127.0.0.1:${entry.proxy.port};https=127.0.0.1:${entry.proxy.port}`,
       proxyBypassRules: '<-loopback>',
     })
-    return { partition, proxied: true, sshLabel: entry.label }
+    return { ok: true, session: { partition, proxied: true, sshLabel: entry.label } }
   }
 
   releaseSession(locationId: string): void {

--- a/apps/desktop/src/renderer/src/stores/__tests__/browser.test.ts
+++ b/apps/desktop/src/renderer/src/stores/__tests__/browser.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useBrowserStore } from '../browser'
+import { useToastStore } from '../toast'
+import { useUiStore } from '../ui'
+
+describe('browser store stale locations', () => {
+  const invoke = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('window', { api: { invoke } })
+    useBrowserStore.setState({
+      tabsByLocation: {},
+      activeByLocation: {},
+      visibleByLocation: {},
+      sessionByLocation: {},
+    })
+    useToastStore.setState({ toasts: [] })
+    useUiStore.setState({
+      locationAuxTabByLocation: {},
+      locationAuxTabRequestByLocation: {},
+    })
+  })
+
+  it('removes persisted browser state when its location no longer exists', async () => {
+    useBrowserStore.setState({
+      tabsByLocation: {
+        deleted: [{
+          id: 'persisted-tab',
+          url: 'http://localhost:5173',
+          title: 'App',
+          faviconUrl: null,
+          loading: false,
+          error: null,
+          canGoBack: false,
+          canGoForward: false,
+        }],
+      },
+      activeByLocation: { deleted: 'persisted-tab' },
+      visibleByLocation: { deleted: false },
+    })
+    useUiStore.setState({ locationAuxTabByLocation: { deleted: 'browser' } })
+    invoke.mockImplementation(async (channel: string) =>
+      channel === 'browser:prepareSession'
+        ? { ok: false, code: 'LOCATION_NOT_FOUND' }
+        : undefined,
+    )
+
+    await useBrowserStore.getState().open('deleted')
+
+    const state = useBrowserStore.getState()
+    expect(state.tabsByLocation.deleted).toBeUndefined()
+    expect(state.activeByLocation.deleted).toBeUndefined()
+    expect(state.visibleByLocation.deleted).toBeUndefined()
+    expect(state.sessionByLocation.deleted).toBeUndefined()
+    expect(useUiStore.getState().locationAuxTabByLocation.deleted).toBeUndefined()
+    expect(useToastStore.getState().toasts).toEqual([
+      expect.objectContaining({ type: 'info', message: 'That project location no longer exists.' }),
+    ])
+  })
+})

--- a/apps/desktop/src/renderer/src/stores/browser.ts
+++ b/apps/desktop/src/renderer/src/stores/browser.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import type { BrowserSessionConfig } from '../types/ipc'
 import { useUiStore } from './ui'
+import { useToastStore } from './toast'
 
 export interface BrowserTab {
   id: string
@@ -29,6 +30,7 @@ interface BrowserStore {
   closeTab: (locationId: string, tabId: string) => Promise<void>
   activateTab: (locationId: string, tabId: string) => void
   updateTab: (locationId: string, tabId: string, patch: Partial<BrowserTab>) => void
+  discardLocation: (locationId: string) => void
 }
 
 let tabCounter = 0
@@ -47,6 +49,12 @@ function makeTab(url: string | null): BrowserTab {
   }
 }
 
+function withoutKey<T>(record: Record<string, T>, key: string): Record<string, T> {
+  const next = { ...record }
+  delete next[key]
+  return next
+}
+
 export const useBrowserStore = create<BrowserStore>((set, get) => ({
   tabsByLocation: {},
   activeByLocation: {},
@@ -58,7 +66,13 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
     const state = get()
     let session = state.sessionByLocation[locationId]
     if (!session) {
-      session = await window.api.invoke('browser:prepareSession', locationId)
+      const result = await window.api.invoke('browser:prepareSession', locationId)
+      if (!result.ok) {
+        get().discardLocation(locationId)
+        useToastStore.getState().add({ type: 'info', message: 'That project location no longer exists.' })
+        return
+      }
+      session = result.session
       set((s) => ({ sessionByLocation: { ...s.sessionByLocation, [locationId]: session! } }))
     }
 
@@ -106,7 +120,13 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
     const state = get()
     let session = state.sessionByLocation[locationId]
     if (!session) {
-      session = await window.api.invoke('browser:prepareSession', locationId)
+      const result = await window.api.invoke('browser:prepareSession', locationId)
+      if (!result.ok) {
+        get().discardLocation(locationId)
+        useToastStore.getState().add({ type: 'info', message: 'That project location no longer exists.' })
+        return
+      }
+      session = result.session
       set((s) => ({ sessionByLocation: { ...s.sessionByLocation, [locationId]: session! } }))
     }
 
@@ -161,5 +181,16 @@ export const useBrowserStore = create<BrowserStore>((set, get) => ({
       next[index] = { ...next[index], ...patch }
       return { tabsByLocation: { ...s.tabsByLocation, [locationId]: next } }
     })
+  },
+
+  discardLocation: (locationId) => {
+    set((s) => ({
+      tabsByLocation: withoutKey(s.tabsByLocation, locationId),
+      activeByLocation: withoutKey(s.activeByLocation, locationId),
+      visibleByLocation: withoutKey(s.visibleByLocation, locationId),
+      sessionByLocation: withoutKey(s.sessionByLocation, locationId),
+    }))
+    useUiStore.getState().clearLocationAuxTab(locationId)
+    void window.api.invoke('browser:releaseSession', locationId).catch(() => { /* ignore */ })
   },
 }))

--- a/apps/desktop/src/renderer/src/stores/locations.ts
+++ b/apps/desktop/src/renderer/src/stores/locations.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { RepoLocation, SshConfig, WslConfig, ConnectionType, LocationPool } from '../types/ipc'
 import { useThreadStore } from './threads'
+import { useBrowserStore } from './browser'
 
 interface LocationStore {
   byProject: Record<string, RepoLocation[]>
@@ -104,6 +105,7 @@ export const useLocationStore = create<LocationStore>((set) => ({
 
   remove: async (id, projectId) => {
     await window.api.invoke('locations:delete', id)
+    useBrowserStore.getState().discardLocation(id)
     set((s) => ({
       byProject: {
         ...s.byProject,
@@ -178,6 +180,7 @@ export const useLocationStore = create<LocationStore>((set) => ({
     }))
     try {
       await window.api.invoke('locations:removeWorktree', id)
+      useBrowserStore.getState().discardLocation(id)
     } catch (error) {
       useThreadStore.setState({
         byProject: threadSnapshot.byProject,

--- a/packages/shared/src/channel-contract.ts
+++ b/packages/shared/src/channel-contract.ts
@@ -53,7 +53,7 @@ import type {
   RemoteHostInput,
   RemoteConnectionStatus,
   RemotePairingInfo,
-  BrowserSessionConfig,
+  BrowserPrepareSessionResult,
   Routine,
   RoutineDraft,
 } from './types'
@@ -217,7 +217,7 @@ export interface ChannelContract {
   'claude-history:listSessions': [[encodedPath: string], ClaudeSession[]]
   'claude-history:importedIds': [[projectId: string], string[]]
   'claude-history:import': [[projectId: string, locationId: string, sessionFilePath: string, sessionId: string, name: string], Thread]
-  'browser:prepareSession': [[locationId: string], BrowserSessionConfig]
+  'browser:prepareSession': [[locationId: string], BrowserPrepareSessionResult]
   'browser:releaseSession': [[locationId: string], void]
   'attachments:save': [[dataUrl: string, filename: string, threadId: string], { tempPath: string; id: string }]
   'attachments:saveFromPath': [[sourcePath: string, threadId: string], { tempPath: string; id: string }]

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -90,6 +90,10 @@ export interface BrowserSessionConfig {
   sshLabel: string | null
 }
 
+export type BrowserPrepareSessionResult =
+  | { ok: true; session: BrowserSessionConfig }
+  | { ok: false; code: 'LOCATION_NOT_FOUND' }
+
 export interface RemoteServerConfig {
   enabled: boolean
   host: string


### PR DESCRIPTION
## Summary
- return a typed `LOCATION_NOT_FOUND` result when browser session preparation races with location deletion
- discard tabs, session, visibility, and auxiliary-panel state for deleted locations
- show an informational notice instead of surfacing a renderer IPC error
- proactively clean browser state after location/worktree deletion
- add a renderer-store regression test for a persisted tab whose location was deleted

Closes #24

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter polycode-electron exec vitest run --project renderer --project shared` (118 tests passed)
- `pnpm test` (963 tests passed; unrelated `src/main/driver/__tests__/runners.test.ts` WSL-detection `beforeAll` timed out after 10s on Windows)