### PR TITLE
Make database downgrade failures recoverable

### DIFF
--- a/apps/desktop/src/main/db/__tests__/startup.test.ts
+++ b/apps/desktop/src/main/db/__tests__/startup.test.ts
@@ -1,0 +1,26 @@
+import Database from 'better-sqlite3'
+import { afterEach, describe, expect, it } from 'vitest'
+import { LATEST_SCHEMA_VERSION, runMigrations } from '../migrations'
+import { startDatabase } from '../startup'
+
+const databases: Database.Database[] = []
+
+afterEach(() => {
+  for (const database of databases.splice(0)) database.close()
+})
+
+describe('database startup', () => {
+  it('returns recovery details when the database schema is one version ahead', () => {
+    const database = new Database(':memory:')
+    databases.push(database)
+    database.pragma(`user_version = ${LATEST_SCHEMA_VERSION + 1}`)
+
+    const result = startDatabase({ initDatabase: () => runMigrations(database) })
+
+    expect(result).toEqual({
+      status: 'requires-newer-app',
+      databaseSchemaVersion: LATEST_SCHEMA_VERSION + 1,
+      supportedSchemaVersion: LATEST_SCHEMA_VERSION,
+    })
+  })
+})

--- a/apps/desktop/src/main/db/index.ts
+++ b/apps/desktop/src/main/db/index.ts
@@ -3,7 +3,11 @@ import { app } from 'electron'
 import path from 'path'
 import { runMigrations } from './migrations'
 
-let db: Database.Database
+let db: Database.Database | undefined
+
+export function getDatabasePath(): string {
+  return path.join(app.getPath('userData'), 'polycode.db')
+}
 
 export function getDb(): Database.Database {
   if (!db) {
@@ -13,20 +17,24 @@ export function getDb(): Database.Database {
 }
 
 export function initDb(): void {
-  const userDataPath = app.getPath('userData')
-  const dbPath = path.join(userDataPath, 'polycode.db')
+  const database = new Database(getDatabasePath())
 
-  db = new Database(dbPath)
+  try {
+    // Enable WAL mode for better concurrent read performance
+    database.pragma('journal_mode = WAL')
+    database.pragma('foreign_keys = ON')
 
-  // Enable WAL mode for better concurrent read performance
-  db.pragma('journal_mode = WAL')
-  db.pragma('foreign_keys = ON')
-
-  runMigrations(db)
+    runMigrations(database)
+    db = database
+  } catch (error) {
+    database.close()
+    throw error
+  }
 }
 
 export function closeDb(): void {
   if (db) {
     db.close()
+    db = undefined
   }
 }

--- a/apps/desktop/src/main/db/migrations.ts
+++ b/apps/desktop/src/main/db/migrations.ts
@@ -16,10 +16,22 @@ const migrations: Migration[] = [
 
 export const LATEST_SCHEMA_VERSION = migrations.at(-1)?.version ?? 0
 
+export class DatabaseSchemaTooNewError extends Error {
+  constructor(
+    public readonly databaseSchemaVersion: number,
+    public readonly supportedSchemaVersion: number
+  ) {
+    super(
+      `Database schema version ${databaseSchemaVersion} is newer than supported version ${supportedSchemaVersion}`
+    )
+    this.name = 'DatabaseSchemaTooNewError'
+  }
+}
+
 export function runMigrations(database: Database.Database): void {
   const currentVersion = database.pragma('user_version', { simple: true }) as number
   if (currentVersion > LATEST_SCHEMA_VERSION) {
-    throw new Error(`Database schema version ${currentVersion} is newer than supported version ${LATEST_SCHEMA_VERSION}`)
+    throw new DatabaseSchemaTooNewError(currentVersion, LATEST_SCHEMA_VERSION)
   }
 
   for (const migration of migrations) {

--- a/apps/desktop/src/main/db/startup.ts
+++ b/apps/desktop/src/main/db/startup.ts
@@ -1,0 +1,28 @@
+import { initDb } from './index'
+import { DatabaseSchemaTooNewError } from './migrations'
+
+export interface DatabaseStartupDependencies {
+  initDatabase: () => void
+}
+
+export interface DatabaseRequiresNewerApp {
+  status: 'requires-newer-app'
+  databaseSchemaVersion: number
+  supportedSchemaVersion: number
+}
+
+export function startDatabase(
+  dependencies: DatabaseStartupDependencies = { initDatabase: initDb }
+): { status: 'ready' } | DatabaseRequiresNewerApp {
+  try {
+    dependencies.initDatabase()
+    return { status: 'ready' }
+  } catch (error) {
+    if (!(error instanceof DatabaseSchemaTooNewError)) throw error
+    return {
+      status: 'requires-newer-app',
+      databaseSchemaVersion: error.databaseSchemaVersion,
+      supportedSchemaVersion: error.supportedSchemaVersion,
+    }
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,9 +1,11 @@
 import { app, BrowserWindow, shell, protocol, net, dialog, ipcMain, powerMonitor } from 'electron'
 import { join } from 'path'
+import { copyFile } from 'fs/promises'
 import { pathToFileURL } from 'url'
 import * as Sentry from '@sentry/electron/main'
 import { initUpdater } from './updater'
-import { initDb, closeDb } from './db/index'
+import { closeDb, getDatabasePath } from './db/index'
+import { startDatabase, type DatabaseRequiresNewerApp } from './db/startup'
 import { resetRunningThreads, hasRunningThreads } from './db/queries'
 import { registerIpcHandlers } from './ipc/handlers'
 import { cleanupAllAttachments, getAttachmentDir } from './attachments'
@@ -137,6 +139,56 @@ if (!isDev) {
 let isQuitting = false
 let runLifecycle: RunLifecycle | null = null
 
+async function recoverFromNewerDatabase(result: DatabaseRequiresNewerApp): Promise<void> {
+  const appVersion = app.getVersion()
+  while (true) {
+    const { response } = await dialog.showMessageBox({
+      type: 'warning',
+      title: 'A newer PolyCode version is required',
+      message: 'This database was opened by a newer version of PolyCode.',
+      detail:
+        `Database schema: ${result.databaseSchemaVersion}\n` +
+        `This PolyCode version: ${appVersion} (supports schema ${result.supportedSchemaVersion})\n\n` +
+        `Install a PolyCode version newer than ${appVersion} to open it. The database was not changed.`,
+      buttons: ['Install Latest Version', 'Back Up Database…', 'Exit'],
+      defaultId: 0,
+      cancelId: 2,
+      noLink: true,
+    })
+
+    if (response === 0) {
+      await shell.openExternal('https://github.com/billpeet/polycode/releases/latest')
+      break
+    }
+    if (response === 2) break
+
+    const sourcePath = getDatabasePath()
+    const backup = await dialog.showSaveDialog({
+      title: 'Back up PolyCode database',
+      defaultPath: `${sourcePath}.backup`,
+      filters: [{ name: 'SQLite database', extensions: ['db', 'backup'] }],
+    })
+    if (!backup.canceled && backup.filePath) {
+      try {
+        await copyFile(sourcePath, backup.filePath)
+        await dialog.showMessageBox({
+          type: 'info',
+          title: 'Backup complete',
+          message: 'Your PolyCode database was backed up successfully.',
+          detail: backup.filePath,
+        })
+      } catch (error) {
+        dialog.showErrorBox(
+          'Backup failed',
+          error instanceof Error ? error.message : String(error)
+        )
+      }
+    }
+  }
+
+  app.quit()
+}
+
 // Register custom protocol for serving attachment files
 protocol.registerSchemesAsPrivileged([
   {
@@ -267,7 +319,7 @@ function createWindow(): BrowserWindow {
   return win
 }
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
   const telemetryEnabled = initializeObservability(observabilityConfigFromEnv(app.getVersion()))
   console.info(`[telemetry] OTLP export ${telemetryEnabled ? 'enabled' : 'disabled'}`)
   installIpcProfiling()
@@ -281,7 +333,11 @@ app.whenReady().then(() => {
     return net.fetch(pathToFileURL(filePath).toString())
   })
 
-  initDb()
+  const databaseStartup = startDatabase()
+  if (databaseStartup.status === 'requires-newer-app') {
+    await recoverFromNewerDatabase(databaseStartup)
+    return
+  }
   resetRunningThreads()
 
   const win = createWindow()


### PR DESCRIPTION
## Summary
- classify newer-schema migration failures with structured version details
- close the rejected SQLite handle and stop normal startup before any database-dependent services run
- show a recovery dialog with supported/detected schema versions and safe install, backup, and exit actions
- add a startup regression test using a database whose `user_version` is one ahead

## Root cause
`initDb()` threw synchronously from the unguarded Electron composition root. Because the migration failure carried only an error string, startup could not distinguish expected version skew from an unexpected database failure or offer recovery.

## Verification
- `pnpm --filter polycode-electron exec vitest run src/main/db/__tests__/startup.test.ts src/main/db/__tests__/migrations.test.ts`
- `pnpm --filter polycode-electron typecheck`
- focused ESLint check for changed files
- full suite: 963 passed, 29 skipped; the existing Windows WSL detection hook in `runners.test.ts` timed out before its 14 tests ran

Closes #25
