### PR TITLE
Recover from transient updater failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,15 @@ jobs:
           POLYCODE_OTLP_ENDPOINT: https://otlp.biap.cc
           POLYCODE_OTLP_HEADERS: ${{ secrets.POLYCODE_OTLP_HEADERS }}
 
-      - name: Build installer and publish to GitHub
+      - name: Build installer and upload draft release
         working-directory: apps/desktop
-        run: pnpm exec electron-builder --win --publish always
+        run: pnpm exec electron-builder --win --publish always --config.publish.releaseType=draft
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_IDENTITY_AUTO_DISCOVERY: false
+
+      # All updater assets exist before the release becomes visible to clients.
+      - name: Publish complete release
+        run: gh release edit "v${{ steps.version.outputs.version }}" --draft=false --latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/desktop/src/main/__tests__/updater.test.ts
+++ b/apps/desktop/src/main/__tests__/updater.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type Listener = (...args: unknown[]) => void
+
+const H = vi.hoisted(() => ({
+  listeners: new Map<string, Listener>(),
+  checkForUpdates: vi.fn<() => Promise<unknown>>(),
+  captureException: vi.fn(),
+  send: vi.fn(),
+}))
+
+vi.mock('electron', () => ({
+  app: { isPackaged: true },
+  BrowserWindow: class {},
+}))
+
+vi.mock('electron-updater', () => ({
+  autoUpdater: {
+    autoDownload: false,
+    autoInstallOnAppQuit: false,
+    checkForUpdates: H.checkForUpdates,
+    quitAndInstall: vi.fn(),
+    on: (event: string, listener: Listener) => H.listeners.set(event, listener),
+  },
+}))
+
+vi.mock('@sentry/electron/main', () => ({ captureException: H.captureException }))
+
+describe('auto-updater transient failures', () => {
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    H.listeners.clear()
+    H.checkForUpdates.mockReset().mockResolvedValue(undefined)
+    H.captureException.mockReset()
+    H.send.mockReset()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  async function initialise() {
+    const updater = await import('../updater')
+    updater.initUpdater(() => ({ webContents: { send: H.send } }) as unknown as import('electron').BrowserWindow)
+    return updater
+  }
+
+  it.each([
+    Object.assign(new Error('net::ERR_NETWORK_IO_SUSPENDED'), { code: 'ERR_NETWORK_IO_SUSPENDED' }),
+    new Error('HttpError: 504 Gateway Timeout'),
+    new Error('Cannot download latest.yml: status 404'),
+    Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }),
+  ])('retries recoverable failure without reporting it: %s', async (error) => {
+    const updater = await initialise()
+    H.listeners.get('update-available')?.({ version: '1.2.3' })
+    H.listeners.get('download-progress')?.({ percent: 41 })
+
+    H.listeners.get('error')?.(error)
+
+    expect(H.captureException).not.toHaveBeenCalled()
+    expect(updater.getUpdateState()).toMatchObject({
+      available: true,
+      version: '1.2.3',
+      progress: 41,
+      checking: false,
+      downloading: false,
+    })
+    expect(updater.getUpdateState().error).toBeUndefined()
+    expect(H.checkForUpdates).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(H.checkForUpdates).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports a recoverable failure only after bounded retries are exhausted', async () => {
+    await initialise()
+    vi.clearAllTimers() // Exclude the independent first scheduled update check.
+    const error = new Error('HttpError: 500 Internal Server Error')
+
+    for (const delay of [2_000, 4_000, 8_000]) {
+      H.listeners.get('error')?.(error)
+      await vi.advanceTimersByTimeAsync(delay)
+    }
+    H.listeners.get('error')?.(error)
+
+    expect(H.checkForUpdates).toHaveBeenCalledTimes(3)
+    expect(H.captureException).toHaveBeenCalledTimes(1)
+    expect(H.captureException).toHaveBeenCalledWith(error, expect.objectContaining({
+      tags: expect.objectContaining({ source: 'auto-updater', retriesExhausted: 'true' }),
+    }))
+  })
+
+  it('reports a non-transient updater error immediately', async () => {
+    await initialise()
+    const error = new Error('sha512 checksum mismatch')
+
+    H.listeners.get('error')?.(error)
+
+    expect(H.captureException).toHaveBeenCalledWith(error, {
+      tags: { source: 'auto-updater' },
+    })
+    expect(H.checkForUpdates).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -104,11 +104,10 @@ function reportFatalProcessError(kind: string, error: unknown): void {
 
 // EPIPE errors from network streams (e.g. electron-updater downloading latest.yml)
 // can escape electron-updater's own error handler and surface as uncaught exceptions.
-// They are not fatal — absorb them and let Sentry record them at warning level.
+// They are not fatal; keep them as an operational warning rather than a Sentry event.
 process.on('uncaughtException', (err: NodeJS.ErrnoException) => {
   if (err.code === 'EPIPE') {
     console.warn('[main] EPIPE on network stream (ignored):', err.message)
-    if (!isDev) Sentry.captureException(err, { level: 'warning', tags: { source: 'epipe' } })
     return
   }
 

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -5,8 +5,12 @@ import type { UpdateState } from '../shared/types'
 
 const FIRST_CHECK_DELAY = 10_000 // 10 seconds after launch
 const UPDATE_CHECK_INTERVAL = 30 * 60 * 1000 // every 30 minutes
+const MAX_TRANSIENT_RETRIES = 3
+const RETRY_BASE_DELAY = 2_000
 
 let getWindow: () => BrowserWindow | null = () => null
+let transientRetryCount = 0
+let retryTimer: ReturnType<typeof setTimeout> | undefined
 
 let updateState: UpdateState = {
   available: false,
@@ -19,7 +23,7 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
-function isExpectedNetworkError(error: unknown): boolean {
+function isTransientUpdateError(error: unknown): boolean {
   const message = getErrorMessage(error)
   const code = typeof error === 'object' && error !== null && 'code' in error
     ? String((error as { code?: unknown }).code)
@@ -29,6 +33,7 @@ function isExpectedNetworkError(error: unknown): boolean {
     'ERR_NAME_NOT_RESOLVED',
     'ERR_INTERNET_DISCONNECTED',
     'ERR_NETWORK_CHANGED',
+    'ERR_NETWORK_IO_SUSPENDED',
     'ERR_CONNECTION_TIMED_OUT',
     'ERR_CONNECTION_RESET',
     'ERR_CONNECTION_REFUSED',
@@ -37,7 +42,54 @@ function isExpectedNetworkError(error: unknown): boolean {
     'ETIMEDOUT',
     'ECONNRESET',
     'ECONNREFUSED',
+    'EPIPE',
   ].some((token) => code === token || message.includes(token))
+    || /\b(?:HTTP(?:Error)?[: ]*)?(?:500|502|503|504)\b/i.test(message)
+    || /\b404\b.*\blatest(?:-[^\s/]+)?\.yml\b|\blatest(?:-[^\s/]+)?\.yml\b.*\b404\b/i.test(message)
+}
+
+function resetTransientRetries(): void {
+  transientRetryCount = 0
+  if (retryTimer) clearTimeout(retryTimer)
+  retryTimer = undefined
+}
+
+function handleUpdateError(error: unknown): void {
+  const message = getErrorMessage(error)
+  if (!isTransientUpdateError(error)) {
+    Sentry.captureException(error, { tags: { source: 'auto-updater' } })
+    console.error('[updater] error:', message)
+    setState({ checking: false, downloading: false, error: message })
+    return
+  }
+
+  // electron-updater can reject checkForUpdates and emit `error` for the same
+  // request. One pending timer makes that pair a single retry attempt.
+  if (retryTimer) return
+
+  if (transientRetryCount >= MAX_TRANSIENT_RETRIES) {
+    console.error(`[updater] transient failure after ${transientRetryCount} retries:`, message)
+    Sentry.captureException(error, {
+      tags: { source: 'auto-updater', retriesExhausted: 'true' },
+      extra: { retryCount: transientRetryCount },
+    })
+    setState({ checking: false, downloading: false, error: message })
+    return
+  }
+
+  const retryNumber = transientRetryCount + 1
+  const exponentialDelay = RETRY_BASE_DELAY * (2 ** transientRetryCount)
+  const jitteredDelay = Math.round(exponentialDelay * (0.75 + Math.random() * 0.5))
+  transientRetryCount = retryNumber
+  console.warn(
+    `[updater] transient failure; retry ${retryNumber}/${MAX_TRANSIENT_RETRIES} in ${jitteredDelay}ms:`,
+    message,
+  )
+  setState({ checking: false, downloading: false, error: undefined })
+  retryTimer = setTimeout(() => {
+    retryTimer = undefined
+    checkForUpdates()
+  }, jitteredDelay)
 }
 
 function broadcast(): void {
@@ -59,15 +111,7 @@ export function getUpdateState(): UpdateState {
 
 export function checkForUpdates(): void {
   if (!app.isPackaged) return
-  autoUpdater.checkForUpdates().catch((err) => {
-    const message = getErrorMessage(err)
-    const log = isExpectedNetworkError(err) ? console.warn : console.error
-    log('[updater] check failed:', message)
-    setState({
-      checking: false,
-      error: message,
-    })
-  })
+  autoUpdater.checkForUpdates().catch(handleUpdateError)
 }
 
 /** Quit and install the downloaded update. Returns false if no update is ready. */
@@ -90,10 +134,12 @@ export function initUpdater(windowGetter: () => BrowserWindow | null): void {
   })
 
   autoUpdater.on('update-not-available', () => {
+    resetTransientRetries()
     setState({ checking: false, available: false, downloading: false })
   })
 
   autoUpdater.on('update-available', (info) => {
+    resetTransientRetries()
     setState({
       checking: false,
       available: true,
@@ -108,6 +154,7 @@ export function initUpdater(windowGetter: () => BrowserWindow | null): void {
   })
 
   autoUpdater.on('update-downloaded', (info) => {
+    resetTransientRetries()
     setState({
       available: true,
       downloading: false,
@@ -118,18 +165,7 @@ export function initUpdater(windowGetter: () => BrowserWindow | null): void {
   })
 
   autoUpdater.on('error', (err) => {
-    if (isExpectedNetworkError(err)) {
-      console.warn('[updater] network unavailable:', err.message)
-    } else {
-      Sentry.captureException(err, { tags: { source: 'auto-updater' } })
-      console.error('[updater] error:', err.message)
-    }
-
-    setState({
-      checking: false,
-      downloading: false,
-      error: err.message,
-    })
+    handleUpdateError(err)
   })
 
   // First check shortly after launch, then periodically


### PR DESCRIPTION
## Summary
- classify Chromium network suspension, socket `EPIPE`, GitHub 5xx responses, and `latest.yml` 404s as transient updater failures
- retry transient failures three times with exponential backoff and jitter while preserving the last known update state
- report to Sentry only for non-transient failures or after transient retries are exhausted
- upload release assets to a draft and publish only after the installer, blockmap, and updater metadata are complete

## Root cause
The updater recognized only a narrow set of network error tokens, so expected transport failures escaped to Sentry. Releases were also made visible while electron-builder was still uploading `latest.yml`, which created a deterministic metadata race for clients checking during publication.

## Verification
- `pnpm --filter polycode-electron typecheck`
- `pnpm exec eslint apps/desktop/src/main/updater.ts apps/desktop/src/main/index.ts apps/desktop/src/main/__tests__/updater.test.ts`
- `vitest run src/main/__tests__/updater.test.ts` (6 passed)
- full `vitest run` (67 files passed, 982 tests passed, 2 files / 15 tests skipped)

Closes #23