### PR TITLE
Fix shutdown database lifecycle

### DIFF
--- a/apps/desktop/src/main/app-lifecycle.test.ts
+++ b/apps/desktop/src/main/app-lifecycle.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  assertAppRunning,
+  getAppLifecycleState,
+  resetAppLifecycleForTest,
+  runAppOperation,
+  shutdownApp,
+  waitForAppOperations,
+} from './app-lifecycle'
+
+describe('application shutdown lifecycle', () => {
+  afterEach(() => resetAppLifecycleForTest())
+
+  it('rejects new IPC and keeps the database open until asynchronous producers stop', async () => {
+    const events: string[] = []
+    let releaseProducers!: () => void
+    const producersStopped = new Promise<void>((resolve) => { releaseProducers = resolve })
+
+    const shutdown = shutdownApp({
+      stopProducers: () => events.push('watchers-and-timers-stopped'),
+      awaitProducers: async () => {
+        events.push('commands-stopping')
+        await producersStopped
+        events.push('commands-stopped')
+      },
+      closeDatabase: () => events.push('database-closed'),
+      finish: () => events.push('shutdown-finished'),
+    })
+
+    expect(getAppLifecycleState()).toBe('closing')
+    expect(() => assertAppRunning()).toThrow('PolyCode is shutting down')
+    expect(events).toEqual(['watchers-and-timers-stopped', 'commands-stopping'])
+
+    releaseProducers()
+    await shutdown
+
+    expect(events).toEqual([
+      'watchers-and-timers-stopped',
+      'commands-stopping',
+      'commands-stopped',
+      'database-closed',
+      'shutdown-finished',
+    ])
+    expect(getAppLifecycleState()).toBe('closed')
+  })
+
+  it('waits for IPC that was already in flight when shutdown began', async () => {
+    const events: string[] = []
+    let releaseIpc!: () => void
+    const ipcReleased = new Promise<void>((resolve) => { releaseIpc = resolve })
+    const ipc = runAppOperation(async () => {
+      events.push('ipc-started')
+      await ipcReleased
+      events.push('ipc-finished')
+    })
+
+    const shutdown = shutdownApp({
+      stopProducers: vi.fn(),
+      awaitProducers: () => waitForAppOperations(),
+      closeDatabase: () => events.push('database-closed'),
+      finish: vi.fn(),
+    })
+
+    await Promise.resolve()
+    expect(events).toEqual(['ipc-started'])
+    releaseIpc()
+    await Promise.all([ipc, shutdown])
+    expect(events).toEqual(['ipc-started', 'ipc-finished', 'database-closed'])
+  })
+
+  it('runs shutdown only once when Electron emits before-quit again', async () => {
+    const steps = {
+      stopProducers: vi.fn(),
+      awaitProducers: vi.fn(async () => undefined),
+      closeDatabase: vi.fn(),
+      finish: vi.fn(),
+    }
+
+    await Promise.all([shutdownApp(steps), shutdownApp(steps)])
+
+    expect(steps.stopProducers).toHaveBeenCalledTimes(1)
+    expect(steps.awaitProducers).toHaveBeenCalledTimes(1)
+    expect(steps.closeDatabase).toHaveBeenCalledTimes(1)
+    expect(steps.finish).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -1,0 +1,73 @@
+export type AppLifecycleState = 'running' | 'closing' | 'closed'
+
+let state: AppLifecycleState = 'running'
+let activeOperations = 0
+const idleWaiters = new Set<() => void>()
+
+export function getAppLifecycleState(): AppLifecycleState {
+  return state
+}
+
+export function beginAppShutdown(): boolean {
+  if (state !== 'running') return false
+  state = 'closing'
+  return true
+}
+
+export function finishAppShutdown(): void {
+  state = 'closed'
+}
+
+export function assertAppRunning(): void {
+  if (state !== 'running') throw new Error('PolyCode is shutting down')
+}
+
+export async function runAppOperation<T>(operation: () => T | Promise<T>): Promise<T> {
+  assertAppRunning()
+  activeOperations += 1
+  try {
+    return await operation()
+  } finally {
+    activeOperations -= 1
+    if (activeOperations === 0) {
+      for (const resolve of idleWaiters) resolve()
+      idleWaiters.clear()
+    }
+  }
+}
+
+export function waitForAppOperations(): Promise<void> {
+  if (activeOperations === 0) return Promise.resolve()
+  return new Promise((resolve) => idleWaiters.add(resolve))
+}
+
+export interface ShutdownSteps {
+  stopProducers(): void
+  awaitProducers(): Promise<unknown>
+  closeDatabase(): void
+  finish(): void
+}
+
+/** Stop every source of asynchronous work before closing the database it uses. */
+export async function shutdownApp(steps: ShutdownSteps): Promise<void> {
+  if (!beginAppShutdown()) return
+
+  try {
+    steps.stopProducers()
+    await steps.awaitProducers()
+  } finally {
+    try {
+      steps.closeDatabase()
+    } finally {
+      finishAppShutdown()
+      steps.finish()
+    }
+  }
+}
+
+/** Test-only reset for this process-wide lifecycle singleton. */
+export function resetAppLifecycleForTest(): void {
+  state = 'running'
+  activeOperations = 0
+  idleWaiters.clear()
+}

--- a/apps/desktop/src/main/control/control-rpc.ts
+++ b/apps/desktop/src/main/control/control-rpc.ts
@@ -1,10 +1,15 @@
 import { BrowserWindow } from 'electron'
 import { REMOTE_CHANNELS, isRemoteChannel } from '@polycode/shared'
 import { invokeChannelHandler, isMigratedChannel } from '../ipc/channel-handlers'
+import { runAppOperation } from '../app-lifecycle'
 
 export const CONTROL_RPC_CHANNELS: ReadonlySet<string> = new Set(REMOTE_CHANNELS)
 
 export async function handleControlRpc(window: BrowserWindow, channel: string, args: unknown[]): Promise<unknown> {
+  return runAppOperation(() => handleControlRpcWhileRunning(window, channel, args))
+}
+
+async function handleControlRpcWhileRunning(window: BrowserWindow, channel: string, args: unknown[]): Promise<unknown> {
   // Channels folded into the typed handler map. The `isRemoteChannel` guard derives
   // reachability from the registry rather than from which switch happens to have a
   // case, so a local-only channel stays unreachable from this transport even once it

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -37,6 +37,7 @@ import {
   shutdownObservability,
   type TelemetryAttributes,
 } from './observability'
+import { getAppLifecycleState, shutdownApp, waitForAppOperations } from './app-lifecycle'
 
 const isDev = !app.isPackaged && process.env.NODE_ENV !== 'production'
 
@@ -378,35 +379,37 @@ app.on('window-all-closed', () => {
   }
 })
 
-let shutdownStarted = false
-let shutdownComplete = false
-
 app.on('before-quit', (event) => {
-  if (shutdownComplete) return
+  if (getAppLifecycleState() !== 'running') return
 
   event.preventDefault()
-  if (shutdownStarted) return
-
-  shutdownStarted = true
-  isQuitting = true
-  runLifecycle?.stop()
-  sessionManager.stopAll()
-  stopWebhookServer()
-  stopRemoteControlClient()
-  stopRemoteControlServer()
-  browserSessionManager.stopAll()
-  stopPlanWatcher()
-  stopAllFileWatches()
-  ptyManager.killAll()
-
-  void Promise.allSettled([
-    commandManager.stopAll(),
-    shutdownObservability(),
-  ]).finally(() => {
-    cleanupAllAttachments()
-    closeDb()
-    flushAppLogs()
-    shutdownComplete = true
-    app.quit()
+  void shutdownApp({
+    stopProducers: () => {
+      isQuitting = true
+      runLifecycle?.stop()
+      sessionManager.stopAll()
+      stopWebhookServer()
+      stopRemoteControlClient()
+      stopRemoteControlServer()
+      browserSessionManager.stopAll()
+      stopPlanWatcher()
+      stopAllFileWatches()
+      ptyManager.killAll()
+    },
+    awaitProducers: async () => {
+      await Promise.allSettled([
+        commandManager.stopAll(),
+        shutdownObservability(),
+        waitForAppOperations(),
+      ])
+    },
+    closeDatabase: () => {
+      cleanupAllAttachments()
+      closeDb()
+    },
+    finish: () => {
+      flushAppLogs()
+      app.quit()
+    },
   })
 })

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -14,6 +14,7 @@ import { restartRemoteControlServer } from '../remote/server'
 import { MIGRATED_CHANNELS, filePathToDataUrl, invokeChannelHandler } from './channel-handlers'
 import type { LocalHandlerContext } from './channel-handlers'
 import type { RunLifecycle } from '../runs/lifecycle'
+import { getAppLifecycleState, runAppOperation } from '../app-lifecycle'
 
 export function registerIpcHandlers(window: BrowserWindow, runLifecycle: RunLifecycle): void {
   commandManager.init(window)
@@ -41,9 +42,11 @@ export function registerIpcHandlers(window: BrowserWindow, runLifecycle: RunLife
     handler: (...args: T) => unknown | Promise<unknown>,
   ): void => {
     ipcMain.handle(channel, async (_event, ...args: T) => {
-      const proxied = await remoteClient.invokeIfActive(channel, args)
-      if (proxied.handled) return proxied.value
-      return handler(...args)
+      return runAppOperation(async () => {
+        const proxied = await remoteClient.invokeIfActive(channel, args)
+        if (proxied.handled) return proxied.value
+        return handler(...args)
+      })
     })
   }
 
@@ -72,23 +75,25 @@ export function registerIpcHandlers(window: BrowserWindow, runLifecycle: RunLife
     // and it is forwarding — an adapter concern — so it stays here rather than in the map.
     if (channel === 'attachments:saveFromPath') {
       ipcMain.handle(channel, async (_event, sourcePath: string, threadId: string) => {
-        // Encode only when there is actually a host to upload to. `invokeIfActive` returns
-        // `handled: true` exactly when `getActiveHost() && shouldProxy(...)`, so hoisting
-        // that condition is equivalent — and it keeps the local path to a single read of
-        // the file, which the map handler does. Computing the data URL unconditionally
-        // here would read and base64 every attachment twice on the common path.
-        if (remoteClient.getActiveHost() && remoteClient.shouldProxy('attachments:save')) {
-          const dataUrl = filePathToDataUrl(sourcePath)
-          const proxied = await remoteClient.invokeIfActive('attachments:save', [
-            dataUrl,
-            basename(sourcePath),
-            threadId,
-          ])
-          if (proxied.handled && proxied.value && typeof proxied.value === 'object') {
-            return { ...proxied.value, dataUrl }
+        return runAppOperation(async () => {
+          // Encode only when there is actually a host to upload to. `invokeIfActive` returns
+          // `handled: true` exactly when `getActiveHost() && shouldProxy(...)`, so hoisting
+          // that condition is equivalent — and it keeps the local path to a single read of
+          // the file, which the map handler does. Computing the data URL unconditionally
+          // here would read and base64 every attachment twice on the common path.
+          if (remoteClient.getActiveHost() && remoteClient.shouldProxy('attachments:save')) {
+            const dataUrl = filePathToDataUrl(sourcePath)
+            const proxied = await remoteClient.invokeIfActive('attachments:save', [
+              dataUrl,
+              basename(sourcePath),
+              threadId,
+            ])
+            if (proxied.handled && proxied.value && typeof proxied.value === 'object') {
+              return { ...proxied.value, dataUrl }
+            }
           }
-        }
-        return invokeLocally(sourcePath, threadId)
+          return invokeLocally(sourcePath, threadId)
+        })
       })
       continue
     }
@@ -102,7 +107,9 @@ export function registerIpcHandlers(window: BrowserWindow, runLifecycle: RunLife
     if (isRemoteChannel(channel)) {
       proxyable(channel, invokeLocally)
     } else {
-      ipcMain.handle(channel, (_event, ...args: unknown[]) => invokeLocally(...args))
+      ipcMain.handle(channel, (_event, ...args: unknown[]) => {
+        return runAppOperation(() => invokeLocally(...args))
+      })
     }
   }
 
@@ -123,13 +130,17 @@ export function registerIpcHandlers(window: BrowserWindow, runLifecycle: RunLife
   // sits outside the fold by design; the matching `invoke` registrations are folded.
 
   ipcMain.on('terminal:write', (_event, terminalId: string, data: string) => {
-    void remoteClient.invokeIfActive('terminal:write', [terminalId, data]).then((proxied) => {
+    if (getAppLifecycleState() !== 'running') return
+    void runAppOperation(async () => {
+      const proxied = await remoteClient.invokeIfActive('terminal:write', [terminalId, data])
       if (!proxied.handled) ptyManager.write(terminalId, data)
     })
   })
 
   ipcMain.on('terminal:resize', (_event, terminalId: string, cols: number, rows: number) => {
-    void remoteClient.invokeIfActive('terminal:resize', [terminalId, cols, rows]).then((proxied) => {
+    if (getAppLifecycleState() !== 'running') return
+    void runAppOperation(async () => {
+      const proxied = await remoteClient.invokeIfActive('terminal:resize', [terminalId, cols, rows])
       if (!proxied.handled) ptyManager.resize(terminalId, cols, rows)
     })
   })


### PR DESCRIPTION
## Summary\n\n- introduce an explicit running/closing/closed application lifecycle\n- stop timers, watchers, servers, sessions, and PTYs before awaiting command shutdown\n- reject new local/remote IPC once shutdown begins and drain requests already in flight before closing SQLite\n- clear the database singleton after close\n\n## Verification\n\n- pnpm test (979 passed, 15 skipped)\n- pnpm --filter polycode-electron typecheck\n- pnpm lint\n\nFixes #22