### PR TITLE
Fix forge prerequisite errors as capability states

### DIFF
--- a/apps/desktop/src/renderer/src/components/right-panel/GitSection.tsx
+++ b/apps/desktop/src/renderer/src/components/right-panel/GitSection.tsx
@@ -15,7 +15,7 @@ import CreatePrModal from './CreatePrModal'
 import { useGitErrorReporter } from '../../lib/gitErrorToast'
 import { subscribeToGitRefresh } from '../../lib/gitRefreshCoordinator'
 import { formatErrorDetails } from '../../lib/errorDetails'
-import { getCachedForge, refreshForge, type ForgeRefreshResult } from '../../lib/forgeRefresh'
+import { getCachedForge, refreshForge, type ForgeCapability, type ForgeRefreshResult } from '../../lib/forgeRefresh'
 
 /** Join a repo path and a relative file path using the separator style implied by the repo path. */
 function joinRepoPath(repoPath: string, relPath: string): string {
@@ -33,6 +33,7 @@ type RepoLinkCacheEntry = {
 }
 
 type PullRequestCacheEntry = {
+  capability: ForgeCapability
   provider: 'azure' | 'github' | null
   pageUrl: string | null
   openPrs: PullRequest[]
@@ -774,6 +775,7 @@ export default function GitSection({ threadId, collapsed, onToggle }: { threadId
   const openPrs = prCache?.openPrs ?? []
   const currentPr = gitStatus ? (prCache?.currentByBranch[gitStatus.branch] ?? null) : null
   const prProvider = prCache?.provider ?? null
+  const prCapability = prCache?.capability ?? null
   const prPageUrl = prCache?.pageUrl ?? null
   const effectiveDefaultBranch = prCache?.defaultBranch ?? defaultBranch
   const prsLoadedForCurrentBranch = !!(projectPath && gitStatus && prCache?.loadedBranches[gitStatus.branch])
@@ -808,6 +810,7 @@ export default function GitSection({ threadId, collapsed, onToggle }: { threadId
     setPrCacheByPath((cache) => ({
       ...cache,
       [projectPath]: {
+        capability: result.capability,
         provider: result.provider,
         pageUrl: result.pageUrl,
         openPrs: result.openPrs,
@@ -1305,10 +1308,10 @@ export default function GitSection({ threadId, collapsed, onToggle }: { threadId
             </button>
             <div className="flex shrink-0 items-center gap-1">
               {prPageUrl && <a href={prPageUrl} target="_blank" rel="noreferrer" className="whitespace-nowrap rounded px-1.5 py-0.5 text-[10px] hover:bg-white/10 transition-colors" style={{ color: 'var(--color-text-muted)' }} title="Open pull requests page">Open</a>}
-              <button onClick={() => void refreshPullRequests({ force: true })} disabled={loadingPrs} className="whitespace-nowrap rounded px-1.5 py-0.5 text-[10px] hover:bg-white/10 transition-colors disabled:opacity-40" style={{ color: 'var(--color-text-muted)' }} title="Retry pull request refresh now">{loadingPrs ? 'Refreshing…' : 'Retry'}</button>
+              <button onClick={() => void refreshPullRequests({ force: true })} disabled={loadingPrs || (prCapability?.available === false && prCapability.reason === 'not-repository')} className="whitespace-nowrap rounded px-1.5 py-0.5 text-[10px] hover:bg-white/10 transition-colors disabled:opacity-40" style={{ color: 'var(--color-text-muted)' }} title="Retry pull request refresh now">{loadingPrs ? 'Refreshing…' : 'Retry'}</button>
             </div>
           </div>
-          {!prsCollapsed && (prError ? <p className="text-[11px] leading-relaxed" style={{ color: '#f87171' }}>{prError}</p> : <>
+          {!prsCollapsed && (prError ? <p className="text-[11px] leading-relaxed" style={{ color: '#f87171' }}>{prError}</p> : prCapability && !prCapability.available ? <div className="rounded px-2 py-2" style={{ background: 'var(--color-surface-2)', border: '1px solid var(--color-border)' }}><p className="text-[11px] leading-relaxed" style={{ color: 'var(--color-text-muted)' }}>{prCapability.message}</p>{prCapability.setupCommand && <button onClick={() => void navigator.clipboard.writeText(prCapability.setupCommand!).catch(() => undefined)} className="mt-2 rounded px-2 py-1 text-[10px] hover:bg-white/10" style={{ border: '1px solid var(--color-border)', color: 'var(--color-text)' }}>Copy setup command</button>}</div> : <>
             <div className="mb-2 rounded px-2 py-1.5" style={{ background: 'var(--color-surface-2)', border: '1px solid var(--color-border)' }}>
               <p className="text-[10px] uppercase tracking-wide" style={{ color: 'var(--color-text-muted)', opacity: 0.8 }}>Current PR</p>
               {currentPr ? <div className="mt-1">
@@ -1324,7 +1327,7 @@ export default function GitSection({ threadId, collapsed, onToggle }: { threadId
             {otherOpenPrsAll.length > 5 && <input type="text" value={prSearch} onChange={(e) => setPrSearch(e.target.value)} placeholder={`Search ${otherOpenPrsAll.length} pull requests…`} className="mb-2 w-full rounded px-2 py-1 text-[11px] outline-none" style={{ background: 'var(--color-surface-2)', border: '1px solid var(--color-border)', color: 'var(--color-text)' }} />}
             <div className="space-y-1 mb-2 overflow-y-auto" style={{ maxHeight: '320px' }}>{otherOpenPrs.length === 0 ? <p className="text-xs" style={{ color: 'var(--color-text-muted)' }}>{otherOpenPrsAll.length === 0 ? 'No open pull requests.' : 'No matching pull requests.'}</p> : otherOpenPrs.map((pr) => <div key={pr.id} className="flex items-center justify-between gap-2 rounded px-2 py-1.5" style={{ background: 'var(--color-surface-2)', border: '1px solid var(--color-border)' }}><div className="min-w-0"><p className="text-xs truncate" style={{ color: 'var(--color-text)' }}>{pr.url ? <a href={pr.url} className="hover:underline" style={{ color: 'var(--color-claude)' }}>#{pr.id}</a> : `#${pr.id}`} {pr.title}</p><p className="text-[10px] truncate" style={{ color: 'var(--color-text-muted)' }}>{pr.sourceBranch} → {pr.targetBranch}</p><PullRequestDetails pr={pr} /></div><div className="flex shrink-0 overflow-hidden rounded" style={{ background: 'var(--color-claude)' }}><button onClick={() => void handleCheckoutPr(pr.id)} disabled={checkingOutPrId === pr.id || checkingOutPrWorktreeId === pr.id} className="px-2 py-1 text-[10px] font-medium transition-opacity disabled:opacity-40" style={{ color: '#fff' }} title={`Checkout PR #${pr.id}`}>{checkingOutPrId === pr.id ? 'Checking…' : checkingOutPrWorktreeId === pr.id ? 'Creating…' : 'C/O'}</button><button onClick={(event) => { const rect = event.currentTarget.getBoundingClientRect(); setPrCheckoutMenu({ pr, x: rect.right - 180, y: rect.bottom }) }} disabled={checkingOutPrId === pr.id || checkingOutPrWorktreeId === pr.id} className="px-1 py-1 text-[10px] transition-opacity disabled:opacity-40 hover:bg-black/10" style={{ borderLeft: '1px solid rgba(255,255,255,0.25)', color: '#fff' }} title="More checkout options" aria-label={`More checkout options for PR #${pr.id}`} aria-haspopup="menu"><svg width="8" height="8" viewBox="0 0 8 8" fill="currentColor" aria-hidden="true"><path d="M0 2l4 4 4-4z" /></svg></button></div></div>)}</div>
             {prCheckoutMenu && <ContextMenu x={prCheckoutMenu.x} y={prCheckoutMenu.y} onClose={() => setPrCheckoutMenu(null)} items={[{ id: 'checkout-worktree', label: 'Checkout in worktree', onSelect: () => handleCheckoutPrInWorktree(prCheckoutMenu.pr) }]} />}
-            <button onClick={() => setShowCreatePr(true)} disabled={!prProvider} className="w-full rounded py-1.5 text-xs font-medium disabled:opacity-40" style={{ background: 'var(--color-surface-2)', border: '1px solid var(--color-border)', color: 'var(--color-text)' }}>Create PR</button>
+            <button onClick={() => setShowCreatePr(true)} disabled={!prProvider || prCapability?.available !== true} className="w-full rounded py-1.5 text-xs font-medium disabled:opacity-40" style={{ background: 'var(--color-surface-2)', border: '1px solid var(--color-border)', color: 'var(--color-text)' }}>Create PR</button>
             {!currentPrIsMerged && postPrActionButton}
           </>)}
         </div>}

--- a/apps/desktop/src/renderer/src/lib/__tests__/forgeRefresh.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/forgeRefresh.test.ts
@@ -8,6 +8,7 @@ describe('forge refresh backoff', () => {
     vi.resetModules()
     vi.useFakeTimers()
     invoke = vi.fn(async (channel: string) => {
+      if (channel === 'git:isRepo') return true
       if (channel === 'git:hostingProvider') return 'github'
       if (channel === 'git:defaultBranch') return 'main'
       if (channel === 'forge:pr:webUrl') return 'https://github.test/pulls'
@@ -20,6 +21,46 @@ describe('forge refresh backoff', () => {
   })
 
   afterEach(() => vi.useRealTimers())
+
+  it('treats a plain or deleted directory as a capability state before forge metadata is read', async () => {
+    invoke.mockImplementation(async (channel: string) => {
+      if (channel === 'git:isRepo') return false
+      throw new Error(`unexpected command for a non-repository: ${channel}`)
+    })
+    const { refreshForge } = await import('../forgeRefresh')
+
+    await expect(refreshForge('C:/deleted-worktree', 'main')).resolves.toMatchObject({
+      capability: { available: false, reason: 'not-repository' },
+      provider: null,
+      openPrs: [],
+    })
+    expect(invoke).toHaveBeenCalledOnce()
+    expect(invoke).toHaveBeenCalledWith('git:isRepo', 'C:/deleted-worktree')
+  })
+
+  it('returns Azure setup instructions instead of rejecting when the optional CLI is absent', async () => {
+    invoke.mockImplementation(async (channel: string) => {
+      if (channel === 'git:isRepo') return true
+      if (channel === 'git:hostingProvider') return 'azure'
+      if (channel === 'git:defaultBranch') return 'main'
+      if (channel === 'forge:pr:webUrl') return 'https://dev.azure.test/pulls'
+      if (channel === 'forge:pr:list') {
+        throw new Error('azdevops CLI not found. Install and configure it first: azdevops setup --org <org> --token <pat> --project <project>')
+      }
+      return null
+    })
+    const { refreshForge } = await import('../forgeRefresh')
+
+    await expect(refreshForge('C:/azure-repo', 'main')).resolves.toMatchObject({
+      capability: {
+        available: false,
+        reason: 'azure-cli-missing',
+        setupCommand: 'azdevops setup --org <org> --token <pat> --project <project>',
+      },
+      provider: 'azure',
+      openPrs: [],
+    })
+  })
 
   it('caches stable provider and repository metadata', async () => {
     const { refreshForge } = await import('../forgeRefresh')
@@ -34,6 +75,7 @@ describe('forge refresh backoff', () => {
   it('publishes and caches the base list before enrichment completes', async () => {
     let finishEnrichment!: (value: Array<{ id: number; title: string }>) => void
     invoke.mockImplementation(async (channel: string) => {
+      if (channel === 'git:isRepo') return true
       if (channel === 'git:hostingProvider') return 'github'
       if (channel === 'git:defaultBranch') return 'main'
       if (channel === 'forge:pr:webUrl') return 'https://github.test/pulls'
@@ -54,6 +96,7 @@ describe('forge refresh backoff', () => {
 
   it('suppresses automatic retries after deterministic failures but permits manual retry', async () => {
     invoke.mockImplementation(async (channel: string) => {
+      if (channel === 'git:isRepo') return true
       if (channel === 'git:hostingProvider') return 'github'
       if (channel === 'git:defaultBranch') return 'main'
       if (channel === 'forge:pr:webUrl') return 'https://github.test/pulls'
@@ -71,6 +114,7 @@ describe('forge refresh backoff', () => {
 
   it('exponentially backs off transient failures', async () => {
     invoke.mockImplementation(async (channel: string) => {
+      if (channel === 'git:isRepo') return true
       if (channel === 'git:hostingProvider') return 'github'
       if (channel === 'git:defaultBranch') return 'main'
       if (channel === 'forge:pr:webUrl') return 'https://github.test/pulls'

--- a/apps/desktop/src/renderer/src/lib/forgeRefresh.ts
+++ b/apps/desktop/src/renderer/src/lib/forgeRefresh.ts
@@ -5,12 +5,22 @@ const BASE_BACKOFF_MS = 30_000
 const MAX_BACKOFF_MS = 15 * 60_000
 
 export type ForgeRefreshResult = {
+  capability: ForgeCapability
   provider: 'azure' | 'github' | null
   defaultBranch: string
   pageUrl: string | null
   openPrs: PullRequest[]
   current: PullRequest | null
 }
+
+export type ForgeCapability =
+  | { available: true; provider: 'azure' | 'github' }
+  | {
+    available: false
+    reason: 'not-repository' | 'no-provider' | 'azure-cli-missing' | 'azure-project-missing'
+    message: string
+    setupCommand?: string
+  }
 
 type Metadata = Pick<ForgeRefreshResult, 'provider' | 'defaultBranch' | 'pageUrl'> & { expiresAt: number }
 type Failure = { attempts: number; retryAt: number; deterministic: boolean; message: string }
@@ -27,6 +37,19 @@ function keyFor(repoPath: string): string {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
+}
+
+const AZURE_SETUP_COMMAND = 'azdevops setup --org <org> --token <pat> --project <project>'
+
+function azureSetupCapability(error: unknown): ForgeCapability | null {
+  const message = errorMessage(error)
+  if (/azdevops cli not found|enoent|is not recognized/i.test(message)) {
+    return { available: false, reason: 'azure-cli-missing', message, setupCommand: AZURE_SETUP_COMMAND }
+  }
+  if (/default azure project|set a default azure project|project.*(?:required|missing)/i.test(message)) {
+    return { available: false, reason: 'azure-project-missing', message, setupCommand: AZURE_SETUP_COMMAND }
+  }
+  return null
 }
 
 export function isDeterministicForgeError(error: unknown): boolean {
@@ -77,18 +100,40 @@ export function refreshForge(
 
   const request = (async () => {
     try {
+      const isRepo = await window.api.invoke('git:isRepo', repoPath)
+      if (!isRepo) {
+        metadataByPath.delete(key)
+        failureByPath.delete(key)
+        const result: ForgeRefreshResult = {
+          capability: { available: false, reason: 'not-repository', message: 'No Git repository found.' },
+          provider: null,
+          defaultBranch: 'main',
+          pageUrl: null,
+          openPrs: [],
+          current: null,
+        }
+        resultByPath.set(key, { ...result, branch })
+        options?.onList?.(result)
+        return result
+      }
       const metadata = await getMetadata(repoPath, force)
       if (!metadata.provider) {
         failureByPath.delete(key)
-        const result = { ...metadata, openPrs: [], current: null }
+        const result: ForgeRefreshResult = {
+          ...metadata,
+          capability: { available: false, reason: 'no-provider', message: 'No supported Git hosting remote found.' },
+          openPrs: [],
+          current: null,
+        }
         resultByPath.set(key, { ...result, branch })
         options?.onList?.(result)
         return result
       }
       const openPrs = await window.api.invoke('forge:pr:list', repoPath)
       const previous = resultByPath.get(key)
-      const listed = {
+      const listed: ForgeRefreshResult = {
         ...metadata,
+        capability: { available: true, provider: metadata.provider },
         openPrs,
         current: previous?.branch === branch ? previous.current : null,
       }
@@ -104,10 +149,19 @@ export function refreshForge(
         : window.api.invoke('forge:pr:current', repoPath, branch).catch(() => listed.current)
       const [enrichedPrs, current] = await Promise.all([enrichment, currentRequest])
       failureByPath.delete(key)
-      const result = { ...metadata, openPrs: enrichedPrs, current }
+      const result: ForgeRefreshResult = { ...listed, openPrs: enrichedPrs, current }
       resultByPath.set(key, { ...result, branch })
       return result
     } catch (error) {
+      const metadata = metadataByPath.get(key)
+      const setup = metadata?.provider === 'azure' ? azureSetupCapability(error) : null
+      if (setup && metadata) {
+        failureByPath.delete(key)
+        const result: ForgeRefreshResult = { ...metadata, capability: setup, openPrs: [], current: null }
+        resultByPath.set(key, { ...result, branch })
+        options?.onList?.(result)
+        return result
+      }
       const previousAttempts = failureByPath.get(key)?.attempts ?? 0
       const attempts = previousAttempts + 1
       const deterministic = isDeterministicForgeError(error)


### PR DESCRIPTION
## Summary
- gate forge refresh on `git:isRepo` so plain directories and deleted worktrees never reach remote/provider probes
- convert missing Azure CLI/default-project failures into typed capability results with a copyable setup command
- gate PR creation while forge capability is unavailable

## Root cause
Forge refresh relied on component-level repository guards, which stale/deleted locations and other callers could bypass. Azure's optional CLI prerequisites were represented only as thrown errors, so expected setup states crossed IPC as rejected promises.

## Tests
- `vitest run --project renderer` (96 tests)
- `tsc --build --noEmit`
- targeted ESLint on changed files
- `git diff --check`

Closes #29
