### PR TITLE
Fix diff language detection for unsupported paths

### DIFF
--- a/apps/desktop/src/renderer/src/components/EditDiffView.tsx
+++ b/apps/desktop/src/renderer/src/components/EditDiffView.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { MultiFileDiff } from '@pierre/diffs/react'
 import type { FileContents } from '@pierre/diffs/react'
+import { diffLanguageFromPath } from '../lib/diffLanguage'
 
 interface Props {
   /** For Edit: old_string to replace */
@@ -13,16 +14,8 @@ interface Props {
   toolName: 'Edit' | 'Write'
 }
 
-/** Guess a language from the file extension for Shiki highlighting. */
-function langFromPath(filePath: string | undefined): string | undefined {
-  if (!filePath) return undefined
-  const ext = filePath.split('.').pop()?.toLowerCase()
-  return ext || undefined
-}
-
-
 export default function EditDiffView({ oldString, newString, filePath, toolName }: Props) {
-  const lang = langFromPath(filePath)
+  const lang = diffLanguageFromPath(filePath)
   const displayName = filePath ?? (toolName === 'Write' ? 'new file' : 'edit')
 
   const oldFile = useMemo<FileContents>(() => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/diffLanguage.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/diffLanguage.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { diffLanguageFromPath } from '../diffLanguage'
+
+describe('diffLanguageFromPath', () => {
+  it('normalizes Windows paths before identifying a known filename', () => {
+    expect(diffLanguageFromPath('api\\Dockerfile')).toBe('docker')
+  })
+
+  it('identifies known filenames in POSIX paths', () => {
+    expect(diffLanguageFromPath('services/api/Makefile')).toBe('makefile')
+  })
+
+  it('maps .NET project files to XML', () => {
+    expect(diffLanguageFromPath('src/App/App.csproj')).toBe('xml')
+  })
+
+  it('uses only the final extension of compound filenames', () => {
+    expect(diffLanguageFromPath('src/button.test.tsx')).toBe('tsx')
+  })
+
+  it('uses canonical Shiki language IDs for common aliases', () => {
+    expect(diffLanguageFromPath('scripts/setup.ps1')).toBe('powershell')
+  })
+
+  it.each([
+    undefined,
+    '',
+    'LICENSE',
+    '.gitignore',
+    'src/example.not-a-shiki-language',
+    'folder.with.dot\\README',
+  ])('falls back to text for an unsupported path: %s', (filePath) => {
+    expect(diffLanguageFromPath(filePath)).toBe('text')
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/diffLanguage.ts
+++ b/apps/desktop/src/renderer/src/lib/diffLanguage.ts
@@ -1,0 +1,46 @@
+import { bundledLanguages } from 'shiki'
+import type { BundledLanguage } from 'shiki'
+
+const FILE_NAME_LANGUAGES: Record<string, BundledLanguage> = {
+  dockerfile: 'docker',
+  makefile: 'makefile',
+}
+
+const EXTENSION_LANGUAGES: Record<string, BundledLanguage> = {
+  csproj: 'xml',
+  fsproj: 'xml',
+  props: 'xml',
+  targets: 'xml',
+  vbproj: 'xml',
+  cs: 'csharp',
+  h: 'c',
+  hpp: 'cpp',
+  js: 'javascript',
+  jsx: 'jsx',
+  md: 'markdown',
+  ps1: 'powershell',
+  py: 'python',
+  rb: 'ruby',
+  sh: 'shellscript',
+  ts: 'typescript',
+  tsx: 'tsx',
+  yml: 'yaml',
+}
+
+/** Return only language IDs that @pierre/diffs can safely resolve through Shiki. */
+export function diffLanguageFromPath(filePath: string | undefined): BundledLanguage | 'text' {
+  if (!filePath) return 'text'
+
+  const fileName = filePath.split(/[/\\]/).pop()?.toLowerCase()
+  if (!fileName) return 'text'
+
+  const fileNameLanguage = FILE_NAME_LANGUAGES[fileName]
+  if (fileNameLanguage) return fileNameLanguage
+
+  const finalDot = fileName.lastIndexOf('.')
+  if (finalDot <= 0 || finalDot === fileName.length - 1) return 'text'
+
+  const extension = fileName.slice(finalDot + 1)
+  const language = EXTENSION_LANGUAGES[extension] ?? extension
+  return language in bundledLanguages ? language as BundledLanguage : 'text'
+}


### PR DESCRIPTION
## Summary
- normalize Windows and POSIX paths before deriving diff languages
- map known filenames and .NET project extensions to canonical Shiki languages
- validate derived IDs against Shiki's bundled language registry and fall back to text
- add regression tests for Windows paths, dotless files, compound names, aliases, and unknown extensions

Closes #27

## Verification
- pnpm --filter polycode-electron exec vitest run --project renderer (105 passed)
- pnpm --filter polycode-electron typecheck
- pnpm exec eslint apps/desktop/src/renderer/src/lib/diffLanguage.ts apps/desktop/src/renderer/src/lib/__tests__/diffLanguage.test.ts apps/desktop/src/renderer/src/components/EditDiffView.tsx --max-warnings 0
- pnpm build

## Existing test failures
pnpm test reaches 981 passing tests, but the unrelated main-process suite currently fails because src/main/__tests__/updater.test.ts mocks do not implement BrowserWindow.isDestroyed(), and the Windows WSL detection hook in unners.test.ts times out. The updater failure reproduces when run in isolation.