### PR TITLE
Fix safe clipboard writes when renderer loses focus

### DIFF
--- a/apps/desktop/src/main/__tests__/channel-handler-migration.test.ts
+++ b/apps/desktop/src/main/__tests__/channel-handler-migration.test.ts
@@ -92,6 +92,7 @@ describe('channel handler map migration', () => {
       'shell:openExternal',
       'attachments:getFileInfo',
       'attachments:saveFromPath',
+      'clipboard:writeText',
       'shell:copyPath',
       'shell:openInExplorer',
       'shell:openInVsCode',

--- a/apps/desktop/src/main/__tests__/dispatch-characterisation.test.ts
+++ b/apps/desktop/src/main/__tests__/dispatch-characterisation.test.ts
@@ -4249,6 +4249,15 @@ const VSCODE_CANDIDATE = IS_WIN ? 'code.cmd' : 'code'
 const spawnEntry = (cmd: string, argv: unknown[], options: unknown): string =>
   `proc.spawn([${JSON.stringify(cmd)},${JSON.stringify(argv)},${JSON.stringify(options)}])`
 
+describe('clipboard:* — local-only, and defined entirely by the side effect', () => {
+  it('clipboard:writeText writes arbitrary renderer text to the native clipboard', async () => {
+    await expectLocalOnly('clipboard:writeText', ['copied text'])
+    expect(await viaIpc('clipboard:writeText', ['copied text'])).toEqual([
+      'clipboard.writeText(["copied text"])',
+    ])
+  })
+})
+
 describe('shell:* — local-only, and defined entirely by the side effect', () => {
   it('shell:copyPath writes the path to the clipboard', async () => {
     await expectLocalOnly('shell:copyPath', ['C:/repo'])

--- a/apps/desktop/src/main/ipc/channel-handlers.ts
+++ b/apps/desktop/src/main/ipc/channel-handlers.ts
@@ -1989,6 +1989,7 @@ export const channelHandlers = {
   // Explorer window, a native file dialog or a terminal belongs to the machine the user is
   // sitting at, and forwarding it to a phone would open it on the wrong desk.
 
+  'clipboard:writeText': (_ctx, text) => clipboard.writeText(text),
   'shell:copyPath': (_ctx, dirPath) => clipboard.writeText(dirPath),
 
   // The one place in the map that deliberately drops its callee's result. `shell.openPath`

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -25,6 +25,7 @@ import { reportReactCommit } from './lib/perf'
 import { getCurrentLocationId } from './lib/currentLocation'
 import UiErrorBoundary from './components/UiErrorBoundary'
 import { useDatabaseSync } from './hooks/useDatabaseSync'
+import { writeClipboardText } from './lib/clipboard'
 
 const SETTING_PROJECT_KEY = 'selectedProjectId'
 const SETTING_THREAD_KEY = 'selectedThreadId'
@@ -108,11 +109,7 @@ export default function App() {
         const selectionText = window.getSelection?.()?.toString() ?? ''
         if (selectionText) {
           e.preventDefault()
-          try {
-            await navigator.clipboard.writeText(selectionText)
-          } catch {
-            // Fall through to the platform handler if clipboard access is denied.
-          }
+          await writeClipboardText(selectionText)
         }
         return
       }

--- a/apps/desktop/src/renderer/src/components/CommandLogs.tsx
+++ b/apps/desktop/src/renderer/src/components/CommandLogs.tsx
@@ -9,6 +9,7 @@ import { useProjectStore } from '../stores/projects'
 import { useThreadStore } from '../stores/threads'
 import { useLocationStore } from '../stores/locations'
 import { registerUrlLinks } from '../lib/xtermLinks'
+import { writeClipboardText } from '../lib/clipboard'
 import { CommandLogLine, CommandStatus } from '../types/ipc'
 
 const EMPTY_PINNED: string[] = []
@@ -135,7 +136,7 @@ function CommandLogPanel({
 
       event.preventDefault()
       event.stopPropagation()
-      void navigator.clipboard.writeText(term.getSelection())
+      void writeClipboardText(term.getSelection())
     }
 
     window.addEventListener('keydown', onKeyDown, true)
@@ -229,7 +230,7 @@ function CommandLogPanel({
     term.open(containerRef.current)
     term.attachCustomKeyEventHandler((event) => {
       if (!isTerminalCopyShortcut(event) || !term.hasSelection()) return true
-      void navigator.clipboard.writeText(term.getSelection())
+      void writeClipboardText(term.getSelection())
       return false
     })
 

--- a/apps/desktop/src/renderer/src/components/MarkdownContent.tsx
+++ b/apps/desktop/src/renderer/src/components/MarkdownContent.tsx
@@ -8,6 +8,7 @@ import {
   handleMarkdownFileLinkClick,
 } from '../lib/markdownFileLinks'
 import { escapeAttr, renderMarkdownLink } from '../lib/markdownLinkRenderer'
+import { writeClipboardText } from '../lib/clipboard'
 import { useFilesStore } from '../stores/files'
 import { useUiStore } from '../stores/ui'
 
@@ -101,7 +102,8 @@ export default function MarkdownContent({ content, className = '' }: Props) {
         e.preventDefault()
         e.stopPropagation()
         const btn = (e.target as HTMLElement).closest('.file-path-copy-btn') as HTMLElement
-        void navigator.clipboard.writeText(copyPath).then(() => {
+        void writeClipboardText(copyPath).then((didCopy) => {
+          if (!didCopy) return
           btn.classList.add('copied')
           btn.setAttribute('title', 'Copied')
           btn.setAttribute('aria-label', 'Copied')
@@ -124,7 +126,8 @@ export default function MarkdownContent({ content, className = '' }: Props) {
       const decoded = decodeAttr(encoded)
       const label = btn.querySelector('.btn-label') as HTMLElement | null
 
-      navigator.clipboard.writeText(decoded).then(() => {
+      void writeClipboardText(decoded).then((didCopy) => {
+        if (!didCopy) return
         if (label) label.textContent = 'copied!'
         btn.classList.add('copied')
         setTimeout(() => {

--- a/apps/desktop/src/renderer/src/components/MessageBubble.tsx
+++ b/apps/desktop/src/renderer/src/components/MessageBubble.tsx
@@ -5,6 +5,7 @@ import ThinkingBlock from './ThinkingBlock'
 import { MessageEntry } from './MessageStream'
 import { parseFileMentions } from './FileMention'
 import { markdownToPlainText } from '../lib/markdownToPlainText'
+import { writeClipboardText } from '../lib/clipboard'
 
 interface Props {
   entry: MessageEntry
@@ -20,9 +21,11 @@ export default function MessageBubble({ entry }: Props) {
 
   const handleCopy = (format: 'text' | 'markdown') => {
     const content = format === 'markdown' ? message.content : markdownToPlainText(message.content)
-    navigator.clipboard.writeText(content).then(() => {
-      setCopied(format)
-      setTimeout(() => setCopied(null), 1800)
+    void writeClipboardText(content).then((didCopy) => {
+      if (didCopy) {
+        setCopied(format)
+        setTimeout(() => setCopied(null), 1800)
+      }
     })
   }
 

--- a/apps/desktop/src/renderer/src/components/Terminal.tsx
+++ b/apps/desktop/src/renderer/src/components/Terminal.tsx
@@ -3,6 +3,7 @@ import { Terminal as XTerm } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import '@xterm/xterm/css/xterm.css'
 import { useTerminalStore } from '../stores/terminal'
+import { writeClipboardText } from '../lib/clipboard'
 
 function isTerminalCopyShortcut(event: KeyboardEvent): boolean {
   if (event.altKey) return false
@@ -67,7 +68,7 @@ export default function TerminalContent({ threadId, locationId }: Props) {
     term.open(containerRef.current)
     term.attachCustomKeyEventHandler((event) => {
       if (!isTerminalCopyShortcut(event) || !term.hasSelection()) return true
-      void navigator.clipboard.writeText(term.getSelection())
+      void writeClipboardText(term.getSelection())
       return false
     })
 

--- a/apps/desktop/src/renderer/src/components/ThreadLogsModal.tsx
+++ b/apps/desktop/src/renderer/src/components/ThreadLogsModal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState, useEffect, useRef } from 'react'
 import { ThreadLogEntry } from '../types/ipc'
 import { useBackdropClose } from '../hooks/useBackdropClose'
+import { writeClipboardText } from '../lib/clipboard'
 
 const TYPE_COLORS: Record<string, string> = {
   message_sent: '#63b3ed',
@@ -135,9 +136,10 @@ export default function ThreadLogsModal({ threadId, onClose }: Props) {
 
   async function copyToClipboard() {
     const text = filtered.map((e) => JSON.stringify(e)).join('\n')
-    await navigator.clipboard.writeText(text)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+    if (await writeClipboardText(text)) {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
   }
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/components/Toast.tsx
+++ b/apps/desktop/src/renderer/src/components/Toast.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useToastStore, Toast } from '../stores/toast'
 import { useBackdropClose } from '../hooks/useBackdropClose'
+import { writeClipboardText } from '../lib/clipboard'
 
 function ErrorDetailsModal({ toast, onClose }: { toast: Toast; onClose: () => void }) {
   const backdropClose = useBackdropClose(onClose)
@@ -9,9 +10,10 @@ function ErrorDetailsModal({ toast, onClose }: { toast: Toast; onClose: () => vo
   const title = toast.title ?? 'Error Details'
 
   async function copyDetails() {
-    await navigator.clipboard.writeText(detailText)
-    setCopied(true)
-    window.setTimeout(() => setCopied(false), 2000)
+    if (await writeClipboardText(detailText)) {
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 2000)
+    }
   }
 
   return (

--- a/apps/desktop/src/renderer/src/lib/__tests__/clipboard.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/clipboard.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { writeClipboardText } from '../clipboard'
+
+describe('writeClipboardText', () => {
+  const browserWriteText = vi.fn<(text: string) => Promise<void>>()
+  const invoke = vi.fn<(channel: string, text: string) => Promise<void>>()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('navigator', { clipboard: { writeText: browserWriteText } })
+    vi.stubGlobal('window', { api: { invoke } })
+  })
+
+  it('writes through the browser clipboard while the document is focused', async () => {
+    browserWriteText.mockResolvedValue(undefined)
+
+    await expect(writeClipboardText('copied text')).resolves.toBe(true)
+
+    expect(browserWriteText).toHaveBeenCalledWith('copied text')
+    expect(invoke).not.toHaveBeenCalled()
+  })
+
+  it('falls back to Electron when browser clipboard access loses focus', async () => {
+    browserWriteText.mockRejectedValue(
+      new DOMException('Document is not focused', 'NotAllowedError'),
+    )
+    invoke.mockResolvedValue(undefined)
+
+    await expect(writeClipboardText('copied text')).resolves.toBe(true)
+
+    expect(invoke).toHaveBeenCalledWith('clipboard:writeText', 'copied text')
+  })
+
+  it('reports failure without rejecting when neither clipboard is available', async () => {
+    browserWriteText.mockRejectedValue(
+      new DOMException('Document is not focused', 'NotAllowedError'),
+    )
+    invoke.mockRejectedValue(new Error('clipboard unavailable'))
+
+    await expect(writeClipboardText('copied text')).resolves.toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/clipboard.ts
+++ b/apps/desktop/src/renderer/src/lib/clipboard.ts
@@ -1,0 +1,20 @@
+/**
+ * Writes text without leaking clipboard failures as unhandled rejections.
+ *
+ * Chromium can reject an otherwise valid clipboard write when the document loses
+ * focus between the user gesture and the write. Electron's main-process clipboard
+ * does not have that focus restriction, so use it as the fallback.
+ */
+export async function writeClipboardText(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch {
+    try {
+      await window.api.invoke('clipboard:writeText', text)
+      return true
+    } catch {
+      return false
+    }
+  }
+}

--- a/packages/shared/src/channel-contract.ts
+++ b/packages/shared/src/channel-contract.ts
@@ -224,6 +224,7 @@ export interface ChannelContract {
   'attachments:cleanup': [[threadId: string], void]
   'attachments:getFileInfo': [[filePath: string], { size: number; mimeType: string } | null]
   'dialog:open-files': [[], string[]]
+  'clipboard:writeText': [[text: string], void]
   'shell:copyPath': [[dirPath: string], void]
   'shell:openExternal': [[url: string], void]
   'shell:openInExplorer': [[dirPath: string], void]

--- a/packages/shared/src/channels.ts
+++ b/packages/shared/src/channels.ts
@@ -216,6 +216,7 @@ export const CHANNEL_REGISTRY = {
   'dialog:open-files': { local: true, remote: false },
   'settings:get': { local: true, remote: false },
   'settings:set': { local: true, remote: false },
+  'clipboard:writeText': { local: true, remote: false },
   'shell:copyPath': { local: true, remote: false },
   'shell:openExternal': { local: true, remote: false },
   'shell:openInExplorer': { local: true, remote: false },


### PR DESCRIPTION
## Summary
- centralize renderer clipboard writes in a non-rejecting helper
- fall back to Electron's main-process clipboard through a typed local-only IPC channel
- migrate every direct renderer clipboard caller and only show copied state on success
- add regression coverage for focus-loss rejection, native fallback, total failure, and IPC dispatch

## Root cause
Chromium rejects navigator.clipboard.writeText when the renderer loses document focus between the click and the write. Several callers did not handle that rejection, so it surfaced in Sentry. The helper now consumes the browser rejection and retries via Electron's native clipboard; even a failed fallback resolves false instead of producing an unhandled rejection.

## Verification
- pnpm --filter polycode-electron exec vitest run --project renderer src/renderer/src/lib/__tests__/clipboard.test.ts (3 passed)
- IPC migration, dispatch characterisation, and preload allowlist tests (346 passed)
- pnpm typecheck
- pnpm lint
- pnpm test: 988 passed, 15 skipped, with 6 pre-existing failures in src/main/__tests__/updater.test.ts because its BrowserWindow stub lacks isDestroyed()

Closes #26