### PR TITLE
Add bounded production memory diagnostics

### DIFF
--- a/apps/desktop/src/main/app-logger.ts
+++ b/apps/desktop/src/main/app-logger.ts
@@ -34,6 +34,7 @@ let flushing = false
 
 const LOG_FLUSH_INTERVAL_MS = 100
 const LOG_FLUSH_BATCH_SIZE = 250
+export const MAX_PENDING_LOG_LINES = 5_000
 
 function formatLocalDay(date: Date): string {
   const year = date.getFullYear()
@@ -73,6 +74,9 @@ function serializeArg(arg: unknown): string {
 
 function appendLogLine(source: LogSource, level: LogLevel, timestamp: string, messages: string[]): void {
   pendingLines.push({ timestamp, line: `[${timestamp}] [${source}] [${level}] ${messages.join(' ')}\n` })
+  if (pendingLines.length > MAX_PENDING_LOG_LINES) {
+    pendingLines.splice(0, pendingLines.length - MAX_PENDING_LOG_LINES)
+  }
   recordLog(level, messages.join(' '), { 'polycode.process.type': source })
   scheduleFlush()
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -38,6 +38,7 @@ import {
   type TelemetryAttributes,
 } from './observability'
 import { getAppLifecycleState, shutdownApp, waitForAppOperations } from './app-lifecycle'
+import { recordMemorySample, startMemoryTelemetry, stopMemoryTelemetry, type MemorySample } from './memory-telemetry'
 
 const isDev = !app.isPackaged && process.env.NODE_ENV !== 'production'
 
@@ -81,6 +82,21 @@ ipcMain.on('telemetry:duration', (_event, payload: unknown) => {
       .map(([key, value]) => [key.slice(0, 64), typeof value === 'string' ? value.slice(0, 128) : value])
   ) as TelemetryAttributes
   recordDuration(candidate.name.slice(0, 128), candidate.durationMs, { process: 'renderer', ...attributes })
+})
+
+ipcMain.on('telemetry:memory', (_event, payload: unknown) => {
+  if (!payload || typeof payload !== 'object') return
+  const candidate = payload as Partial<MemorySample>
+  const values = [
+    candidate.privateBytes,
+    candidate.residentSetBytes,
+    candidate.sharedBytes,
+    candidate.heapUsedBytes,
+    candidate.heapTotalBytes,
+    candidate.heapLimitBytes,
+  ]
+  if (candidate.process !== 'renderer' || values.some((value) => typeof value !== 'number' || !Number.isFinite(value) || value < 0)) return
+  recordMemorySample(candidate as MemorySample)
 })
 
 let fatalDialogShown = false
@@ -320,6 +336,7 @@ function createWindow(): BrowserWindow {
 app.whenReady().then(async () => {
   const telemetryEnabled = initializeObservability(observabilityConfigFromEnv(app.getVersion()))
   console.info(`[telemetry] OTLP export ${telemetryEnabled ? 'enabled' : 'disabled'}`)
+  startMemoryTelemetry()
   installIpcProfiling()
 
   // Register protocol handler for attachment:// URLs
@@ -394,6 +411,7 @@ app.on('before-quit', (event) => {
       stopPlanWatcher()
       stopAllFileWatches()
       ptyManager.killAll()
+      stopMemoryTelemetry()
     },
     awaitProducers: async () => {
       await Promise.allSettled([

--- a/apps/desktop/src/main/memory-telemetry.test.ts
+++ b/apps/desktop/src/main/memory-telemetry.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { recordGauge } = vi.hoisted(() => ({ recordGauge: vi.fn() }))
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => '1.2.3' },
+}))
+vi.mock('./observability', () => ({ recordGauge }))
+
+import { recordMemorySample } from './memory-telemetry'
+
+describe('memory telemetry', () => {
+  beforeEach(() => recordGauge.mockClear())
+
+  it('records process and heap byte gauges with bounded attributes', () => {
+    recordMemorySample({
+      process: 'renderer',
+      privateBytes: 1,
+      residentSetBytes: 2,
+      sharedBytes: 3,
+      heapUsedBytes: 4,
+      heapTotalBytes: 5,
+      heapLimitBytes: 6,
+    })
+
+    expect(recordGauge.mock.calls).toEqual([
+      ['polycode.process.memory.private', 1, 'By', { 'polycode.process.type': 'renderer', 'polycode.release': '1.2.3' }],
+      ['polycode.process.memory.resident_set', 2, 'By', { 'polycode.process.type': 'renderer', 'polycode.release': '1.2.3' }],
+      ['polycode.process.memory.shared', 3, 'By', { 'polycode.process.type': 'renderer', 'polycode.release': '1.2.3' }],
+      ['polycode.process.heap.used', 4, 'By', { 'polycode.process.type': 'renderer', 'polycode.release': '1.2.3' }],
+      ['polycode.process.heap.total', 5, 'By', { 'polycode.process.type': 'renderer', 'polycode.release': '1.2.3' }],
+      ['polycode.process.heap.limit', 6, 'By', { 'polycode.process.type': 'renderer', 'polycode.release': '1.2.3' }],
+    ])
+  })
+})

--- a/apps/desktop/src/main/memory-telemetry.ts
+++ b/apps/desktop/src/main/memory-telemetry.ts
@@ -1,0 +1,61 @@
+import { app } from 'electron'
+import { getHeapStatistics } from 'node:v8'
+import { recordGauge, type TelemetryAttributes } from './observability'
+
+export const MEMORY_SAMPLE_INTERVAL_MS = 30_000
+
+export interface MemorySample {
+  process: 'main' | 'renderer'
+  privateBytes: number
+  residentSetBytes: number
+  sharedBytes: number
+  heapUsedBytes: number
+  heapTotalBytes: number
+  heapLimitBytes: number
+}
+
+let sampleTimer: NodeJS.Timeout | null = null
+
+export function recordMemorySample(sample: MemorySample): void {
+  const attributes: TelemetryAttributes = {
+    'polycode.process.type': sample.process,
+    'polycode.release': app.getVersion(),
+  }
+  recordGauge('polycode.process.memory.private', sample.privateBytes, 'By', attributes)
+  recordGauge('polycode.process.memory.resident_set', sample.residentSetBytes, 'By', attributes)
+  recordGauge('polycode.process.memory.shared', sample.sharedBytes, 'By', attributes)
+  recordGauge('polycode.process.heap.used', sample.heapUsedBytes, 'By', attributes)
+  recordGauge('polycode.process.heap.total', sample.heapTotalBytes, 'By', attributes)
+  recordGauge('polycode.process.heap.limit', sample.heapLimitBytes, 'By', attributes)
+}
+
+export async function sampleMainProcessMemory(): Promise<void> {
+  const [memory, heap] = await Promise.all([
+    process.getProcessMemoryInfo(),
+    Promise.resolve(getHeapStatistics()),
+  ])
+  recordMemorySample({
+    process: 'main',
+    privateBytes: memory.private * 1024,
+    residentSetBytes: memory.residentSet * 1024,
+    sharedBytes: memory.shared * 1024,
+    heapUsedBytes: heap.used_heap_size,
+    heapTotalBytes: heap.total_heap_size,
+    heapLimitBytes: heap.heap_size_limit,
+  })
+}
+
+export function startMemoryTelemetry(): void {
+  if (sampleTimer) return
+  void sampleMainProcessMemory().catch((error) => console.warn('[telemetry] Memory sample failed', error))
+  sampleTimer = setInterval(() => {
+    void sampleMainProcessMemory().catch((error) => console.warn('[telemetry] Memory sample failed', error))
+  }, MEMORY_SAMPLE_INTERVAL_MS)
+  sampleTimer.unref()
+}
+
+export function stopMemoryTelemetry(): void {
+  if (!sampleTimer) return
+  clearInterval(sampleTimer)
+  sampleTimer = null
+}

--- a/apps/desktop/src/main/observability.ts
+++ b/apps/desktop/src/main/observability.ts
@@ -5,6 +5,7 @@ import {
   type Attributes,
   type Counter,
   type Histogram,
+  type Gauge,
   type Span,
 } from '@opentelemetry/api'
 import { AsyncLocalStorage } from 'node:async_hooks'
@@ -37,6 +38,7 @@ interface ObservabilityState {
   loggerProvider: LoggerProvider
   counters: Map<string, Counter>
   histograms: Map<string, Histogram>
+  gauges: Map<string, Gauge>
 }
 
 let state: ObservabilityState | null = null
@@ -111,8 +113,30 @@ export function initializeObservability(config: ObservabilityConfig): boolean {
     })],
   })
 
-  state = { tracerProvider, meterProvider, loggerProvider, counters: new Map(), histograms: new Map() }
+  state = {
+    tracerProvider,
+    meterProvider,
+    loggerProvider,
+    counters: new Map(),
+    histograms: new Map(),
+    gauges: new Map(),
+  }
   return true
+}
+
+export function recordGauge(
+  name: string,
+  value: number,
+  unit: string,
+  attributes: TelemetryAttributes = {}
+): void {
+  if (!state || !Number.isFinite(value) || value < 0) return
+  let gauge = state.gauges.get(name)
+  if (!gauge) {
+    gauge = state.meterProvider.getMeter('polycode').createGauge(name, { unit })
+    state.gauges.set(name, gauge)
+  }
+  gauge.record(value, attributes)
 }
 
 export function count(name: string, attributes: TelemetryAttributes = {}, value = 1): void {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import { isLocalChannel } from '@polycode/shared'
+import { getHeapStatistics } from 'node:v8'
 
 export type IpcListener = (...args: unknown[]) => void
 
@@ -46,3 +47,35 @@ const api = {
 }
 
 contextBridge.exposeInMainWorld('api', api)
+
+const MEMORY_SAMPLE_INTERVAL_MS = 30_000
+
+async function reportMemory(): Promise<void> {
+  const [memory, heap] = await Promise.all([
+    process.getProcessMemoryInfo(),
+    Promise.resolve(getHeapStatistics()),
+  ])
+  ipcRenderer.send('telemetry:memory', {
+    process: 'renderer',
+    privateBytes: memory.private * 1024,
+    residentSetBytes: memory.residentSet * 1024,
+    sharedBytes: memory.shared * 1024,
+    heapUsedBytes: heap.used_heap_size,
+    heapTotalBytes: heap.total_heap_size,
+    heapLimitBytes: heap.heap_size_limit,
+  })
+}
+
+function reportMemorySafely(): void {
+  void reportMemory().catch((error) => {
+    ipcRenderer.send('log:write', {
+      source: 'renderer',
+      level: 'warn',
+      timestamp: new Date().toISOString(),
+      messages: [`[telemetry] Memory sample failed: ${String(error)}`],
+    })
+  })
+}
+
+reportMemorySafely()
+setInterval(reportMemorySafely, MEMORY_SAMPLE_INTERVAL_MS)


### PR DESCRIPTION
## Summary

- sample Electron main and renderer process memory plus V8 heap statistics every 30 seconds
- export byte-valued OTLP gauges tagged by release and process type
- validate renderer memory telemetry at the main-process IPC boundary
- cap the pending app-log queue at 5,000 lines so stalled disk writes cannot retain logs indefinitely
- stop main-process sampling during orderly shutdown and contain sampling failures

## Why

Issue #33 documents native OOM crashes without enough evidence to attribute a leak. This adds the diagnostic baseline needed to distinguish main/renderer growth and heap/non-heap growth, while bounding one concrete retention path. It intentionally does not cap persisted conversation history without pagination because doing so would silently make older messages inaccessible.

## Verification

- pnpm --filter polycode-electron typecheck
- pnpm --filter polycode-electron exec vitest run src/main/memory-telemetry.test.ts src/main/observability.test.ts
- pnpm exec eslint apps/desktop/src/main/memory-telemetry.ts apps/desktop/src/main/memory-telemetry.test.ts apps/desktop/src/main/observability.ts apps/desktop/src/main/app-logger.ts apps/desktop/src/main/index.ts apps/desktop/src/preload/index.ts
- git diff --check

The full desktop suite reached 988 passing tests, with 9 unrelated existing failures: updater mocks lack BrowserWindow.isDestroyed, and WSL/SSH runner tests time out or leak runner calls in this environment.

Closes #33