### PR TITLE
Validate thread location before creation

### DIFF
--- a/apps/desktop/src/main/__tests__/dispatch-characterisation.test.ts
+++ b/apps/desktop/src/main/__tests__/dispatch-characterisation.test.ts
@@ -321,17 +321,13 @@ vi.mock('../db/queries', () => H.autoModule('db', {
   getThreadWsl: H.stub('db.getThreadWsl', () => H.state.threadWsl),
   threadExists: H.stub('db.threadExists', () => H.state.threadExists),
   threadHasMessages: H.stub('db.threadHasMessages', () => H.state.threadHasMessages),
-  // Recorded, not a bare function: `threads:create` derives provider/model through it and
-  // the derivation itself — that it happens, and before createThread — is the behaviour.
-  getLastUsedProviderAndModel: H.stub('db.getLastUsedProviderAndModel', {
-    provider: 'claude',
-    model: 'opus',
-  }),
   listLocations: H.stub('db.listLocations', () => (H.state.location ? [H.state.location] : [])),
   listThreads: H.stub('db.listThreads', [{ id: 't1', name: 'Thread one' }]),
   listArchivedThreads: H.stub('db.listArchivedThreads', [{ id: 't-old', name: 'Old thread' }]),
   archivedThreadCount: H.stub('db.archivedThreadCount', 7),
-  createThread: H.stub('db.createThread', { id: 't-new', name: 'New thread' }),
+  createThreadForLocation: H.stub(
+    'db.createThreadForLocation', { id: 't-new', name: 'New thread' },
+  ),
   getThreadModifiedFiles: H.stub('db.getThreadModifiedFiles', ['src/a.ts']),
   archiveThread: H.stub('db.archiveThread', 'RET_archiveThread'),
   // Sentinel returns for functions currently declared `: void`. Real code ignores these,
@@ -1839,18 +1835,14 @@ describe('threads:* CRUD and settings — both transports agree', () => {
     ])
   })
 
-  it('threads:create derives provider/model from the project before inserting', async () => {
+  it('threads:create delegates validation and insertion to the transactional query', async () => {
     const args = ['p1', 'New thread', 'loc1']
     const ipc = await viaIpc('threads:create', args)
     const rpc = await viaControlRpc('threads:create', args)
 
     expect(rpc).toEqual(ipc)
-    // The derivation is the behaviour: createThread's own `provider = 'claude-code'` /
-    // `model = 'claude-opus-4-8'` parameter defaults would otherwise silently take over,
-    // so dropping the lookup would still produce a valid-looking thread.
     expect(ipc).toEqual([
-      'db.getLastUsedProviderAndModel(["p1"])',
-      'db.createThread(["p1","New thread","loc1","claude","opus"])',
+      'db.createThreadForLocation(["p1","New thread","loc1"])',
     ])
 
     expect(await resultViaIpc('threads:create', args)).toEqual({ id: 't-new', name: 'New thread' })

--- a/apps/desktop/src/main/db/__tests__/thread-creation.test.ts
+++ b/apps/desktop/src/main/db/__tests__/thread-creation.test.ts
@@ -1,0 +1,61 @@
+import Database from 'better-sqlite3'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { runMigrations } from '../migrations'
+
+let database: Database.Database
+
+vi.mock('../index', () => ({ getDb: () => database }))
+
+const { createThreadForLocation, StaleThreadSelectionError } = await import('../queries')
+
+beforeEach(() => {
+  database = new Database(':memory:')
+  database.pragma('foreign_keys = ON')
+  runMigrations(database)
+
+  const now = new Date().toISOString()
+  const insertProject = database.prepare(
+    'INSERT INTO projects (id, name, path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)'
+  )
+  insertProject.run('p1', 'Project one', 'C:/one', now, now)
+  insertProject.run('p2', 'Project two', 'C:/two', now, now)
+  database.prepare(
+    'INSERT INTO repo_locations (id, project_id, label, path, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)'
+  ).run('loc-1', 'p1', 'Local', 'C:/one', now, now)
+})
+
+afterEach(() => {
+  database.close()
+})
+
+describe('transactional thread creation', () => {
+  it('rejects a location that was deleted before creation with a typed stale-selection error', () => {
+    database.prepare('DELETE FROM repo_locations WHERE id = ?').run('loc-1')
+
+    expect(() => createThreadForLocation('p1', 'New thread', 'loc-1'))
+      .toThrow(StaleThreadSelectionError)
+    expect(() => createThreadForLocation('p1', 'New thread', 'loc-1'))
+      .toThrow('The selected project location is no longer available. Refresh and try again.')
+  })
+
+  it('rejects a location belonging to another project', () => {
+    expect(() => createThreadForLocation('p2', 'New thread', 'loc-1'))
+      .toThrow(StaleThreadSelectionError)
+  })
+
+  it('derives provider and model and inserts for the validated project/location pair', () => {
+    const previous = createThreadForLocation('p1', 'Previous', 'loc-1')
+    database.prepare(
+      'UPDATE threads SET provider = ?, model = ?, provider_model_updated_at = ? WHERE id = ?'
+    ).run('codex', 'gpt-5.6', new Date().toISOString(), previous.id)
+
+    const created = createThreadForLocation('p1', 'New thread', 'loc-1')
+
+    expect(created).toMatchObject({
+      project_id: 'p1',
+      location_id: 'loc-1',
+      provider: 'codex',
+      model: 'gpt-5.6',
+    })
+  })
+})

--- a/apps/desktop/src/main/db/queries.ts
+++ b/apps/desktop/src/main/db/queries.ts
@@ -698,6 +698,39 @@ export interface CreateThreadOptions {
   permissionMode?: PermissionMode
 }
 
+export class StaleThreadSelectionError extends Error {
+  readonly code = 'STALE_THREAD_SELECTION' as const
+
+  constructor() {
+    super('The selected project location is no longer available. Refresh and try again.')
+    this.name = 'StaleThreadSelectionError'
+  }
+}
+
+/**
+ * Creates a user-selected thread from a transactionally validated location.
+ * Provider/model derivation belongs inside the same transaction so project or
+ * location deletion cannot invalidate either lookup before the insert.
+ */
+export function createThreadForLocation(
+  projectId: string,
+  name: string,
+  locationId: string
+): Thread {
+  const db = getDb()
+  return db.transaction(() => {
+    const location = db.prepare('SELECT project_id FROM repo_locations WHERE id = ?')
+      .get(locationId) as { project_id: string } | undefined
+
+    if (!location || location.project_id !== projectId) {
+      throw new StaleThreadSelectionError()
+    }
+
+    const { provider, model } = getLastUsedProviderAndModel(projectId)
+    return createThread(projectId, name, locationId, provider, model)
+  })()
+}
+
 export function createThread(projectId: string, name: string, locationId: string | null, provider = 'claude-code', model = 'claude-opus-4-8', gitBranch: string | null = null, opts: CreateThreadOptions = {}): Thread {
   const now = new Date().toISOString()
   const permissionMode = normalizePermissionMode(opts.permissionMode ?? 'ask')

--- a/apps/desktop/src/main/ipc/channel-handlers.ts
+++ b/apps/desktop/src/main/ipc/channel-handlers.ts
@@ -78,7 +78,7 @@ import {
   createProject,
   createRoutine,
   createSlashCommand,
-  createThread,
+  createThreadForLocation,
   createYouTrackServer,
   deleteCommand,
   deleteLocation,
@@ -90,7 +90,6 @@ import {
   deleteYouTrackServer,
   getActiveSession,
   getImportedSessionIds,
-  getLastUsedProviderAndModel,
   getLocationForThread,
   getProjectById,
   getRoutine,
@@ -862,14 +861,8 @@ export const channelHandlers = {
   'threads:listQueueSnoozed': (_ctx, search, limit, offset) =>
     listSnoozedQueueThreads(search, limit, offset),
 
-  // The provider/model lookup is load-bearing, not decoration: `createThread` declares
-  // `provider = 'claude-code', model = 'claude-opus-4-8'` parameter defaults, so dropping
-  // it would still produce a valid-looking thread that had silently stopped inheriting
-  // what the project last used.
-  'threads:create': (_ctx, projectId, name, locationId) => {
-    const { provider, model } = getLastUsedProviderAndModel(projectId)
-    return createThread(projectId, name, locationId, provider, model)
-  },
+  'threads:create': (_ctx, projectId, name, locationId) =>
+    createThreadForLocation(projectId, name, locationId),
 
   'threads:delete': (_ctx, id) => {
     sessionManager.remove(id)

--- a/apps/desktop/src/renderer/src/stores/threads.ts
+++ b/apps/desktop/src/renderer/src/stores/threads.ts
@@ -4,6 +4,11 @@ import { useToastStore } from './toast'
 import { formatErrorDetails } from '../lib/errorDetails'
 
 const ARCHIVED_THREADS_PAGE_SIZE = 10
+const STALE_THREAD_SELECTION_MESSAGE = 'The selected project location is no longer available.'
+
+function isStaleThreadSelectionError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes(STALE_THREAD_SELECTION_MESSAGE)
+}
 
 function makeOptimisticThreadId(): string {
   return `pending-thread-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
@@ -368,10 +373,17 @@ export const useThreadStore = create<ThreadStore>((set, get) => ({
       return thread.id
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
+      const staleSelection = isStaleThreadSelectionError(error)
+      if (staleSelection) {
+        const { useLocationStore } = await import('./locations')
+        void useLocationStore.getState().fetch(projectId).catch(() => undefined)
+      }
       useToastStore.getState().add({
         type: 'error',
         title: 'Create Thread Failed',
-        message: 'Failed to create the new thread',
+        message: staleSelection
+          ? 'That location changed. Select an available location and try again.'
+          : 'Failed to create the new thread',
         details: formatErrorDetails({
           action: 'threads:create',
           projectId,
@@ -623,10 +635,17 @@ export const useThreadStore = create<ThreadStore>((set, get) => ({
       })
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
+      const staleSelection = isStaleThreadSelectionError(error)
+      if (staleSelection) {
+        const { useLocationStore } = await import('./locations')
+        void useLocationStore.getState().fetch(projectId).catch(() => undefined)
+      }
       useToastStore.getState().add({
         type: 'error',
         title: 'Create Thread Failed',
-        message: 'Failed to create new thread',
+        message: staleSelection
+          ? 'That location changed. Select an available location and try again.'
+          : 'Failed to create new thread',
         details: formatErrorDetails({
           action: 'threads:create',
           projectId,


### PR DESCRIPTION
## Summary

- validate the selected location exists and belongs to the requested project inside the thread-creation transaction
- derive provider/model and insert the thread within that same transaction
- return an actionable typed stale-selection error and refresh renderer location state
- cover deleted, cross-project, and valid inherited-provider/model cases

## Root cause

The create handler derived provider/model separately and then passed independent project and location IDs to the raw insert. A stale location hit SQLite's foreign-key constraint, while a valid location owned by another project was accepted because each foreign key was independently valid.

## Verification

- pnpm --filter polycode-electron exec vitest run src/main/db/__tests__/thread-creation.test.ts src/main/__tests__/dispatch-characterisation.test.ts src/renderer/src/stores/__tests__/threads.test.ts (341 passed)
- pnpm exec eslint apps/desktop/src/main/db/queries.ts apps/desktop/src/main/ipc/channel-handlers.ts apps/desktop/src/main/__tests__/dispatch-characterisation.test.ts apps/desktop/src/main/db/__tests__/thread-creation.test.ts apps/desktop/src/renderer/src/stores/threads.ts --max-warnings 0
- pnpm --filter polycode-electron typecheck

Closes #31