### PR TITLE
fix: harden remote RPC connectivity

### DIFF
--- a/apps/desktop/src/main/__tests__/remote-client-connectivity.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-client-connectivity.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const H = vi.hoisted(() => ({
+  settings: new Map<string, string>(),
+  fetch: vi.fn<typeof fetch>(),
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+}))
+vi.mock('../db/queries', () => ({
+  getSetting: (key: string) => H.settings.get(key) ?? null,
+  setSetting: (key: string, value: string) => H.settings.set(key, value),
+}))
+vi.mock('../app-events', () => ({ emitAppEvent: () => {}, sendToRenderer: () => {} }))
+
+const { RemoteControlClient, RemoteUnavailableError } = await import('../remote/client')
+
+const host = {
+  id: 'host-1',
+  label: 'Studio',
+  baseUrl: 'http://polycode.local:3285',
+  token: 'secret',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+}
+const window = { webContents: { isDestroyed: () => false, send: () => {} } }
+
+function activeClient(): InstanceType<typeof RemoteControlClient> {
+  const client = new RemoteControlClient(window as unknown as import('electron').BrowserWindow)
+  H.settings.set('remote:hosts', JSON.stringify([host]))
+  H.settings.set('remote:activeHostId', host.id)
+  return client
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('RemoteControlClient connectivity failures', () => {
+  beforeEach(() => {
+    H.settings.clear()
+    H.fetch.mockReset()
+    vi.stubGlobal('fetch', H.fetch)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('opens a circuit after transport loss and stops subsequent RPC fan-out', async () => {
+    H.fetch.mockRejectedValue(new TypeError('fetch failed'))
+    const client = activeClient()
+
+    await expect(client.invokeIfActive('projects:list', [])).rejects.toMatchObject({
+      name: 'RemoteUnavailableError',
+      code: 'REMOTE_UNAVAILABLE',
+      hostId: host.id,
+    })
+    await expect(client.invokeIfActive('threads:list', [])).rejects.toBeInstanceOf(RemoteUnavailableError)
+
+    expect(H.fetch).toHaveBeenCalledTimes(1)
+    client.stop()
+  })
+
+  it('turns a 421 health response into an actionable hostname mismatch', async () => {
+    H.fetch.mockResolvedValue(jsonResponse(421, { error: 'Misdirected request' }))
+    const client = new RemoteControlClient(window as unknown as import('electron').BrowserWindow)
+
+    await expect(client.testHost({ label: host.label, baseUrl: host.baseUrl, token: host.token }))
+      .resolves.toEqual({
+        ok: false,
+        error: 'The remote host rejected hostname "polycode.local". Use a URL whose hostname matches the remote server bind host.',
+      })
+    client.stop()
+  })
+
+  it('distinguishes an HTML 200 proxy response from a failed RPC', async () => {
+    H.fetch.mockResolvedValue(new Response('<html><title>Sign in</title></html>', {
+      status: 200,
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    }))
+    const client = activeClient()
+
+    await expect(client.invokeIfActive('projects:list', [])).rejects.toThrow(
+      'Remote host returned text/html instead of JSON (HTTP 200): <html><title>Sign in</title></html>',
+    )
+    client.stop()
+  })
+
+  it('times out a hung RPC and opens the unavailable circuit', async () => {
+    vi.useFakeTimers()
+    H.fetch.mockImplementation((_url, init) => new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')))
+    }))
+    const client = activeClient()
+    const request = client.invokeIfActive('projects:list', [])
+    const verdict = expect(request).rejects.toMatchObject({ code: 'REMOTE_UNAVAILABLE' })
+
+    await vi.advanceTimersByTimeAsync(10_000)
+    await verdict
+    await expect(client.invokeIfActive('threads:list', [])).rejects.toMatchObject({ code: 'REMOTE_UNAVAILABLE' })
+    expect(H.fetch).toHaveBeenCalledTimes(1)
+    client.stop()
+  })
+})

--- a/apps/desktop/src/main/remote/client.ts
+++ b/apps/desktop/src/main/remote/client.ts
@@ -23,6 +23,31 @@ interface ProxyResult {
   value?: unknown
 }
 
+const RPC_TIMEOUT_MS = 10_000
+const RESPONSE_DIAGNOSTIC_LIMIT = 240
+const RECONNECT_BASE_DELAY_MS = 2_000
+const RECONNECT_MAX_DELAY_MS = 30_000
+
+export class RemoteUnavailableError extends Error {
+  readonly code = 'REMOTE_UNAVAILABLE'
+
+  constructor(
+    readonly hostId: string,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options)
+    this.name = 'RemoteUnavailableError'
+  }
+}
+
+class RemoteProtocolError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'RemoteProtocolError'
+  }
+}
+
 let activeClient: RemoteControlClient | null = null
 
 function readHosts(): RemoteHost[] {
@@ -86,17 +111,42 @@ function errorMessage(error: unknown): string {
 }
 
 async function readJsonResponse(response: Response): Promise<RpcResponse> {
-  try {
-    return await response.json() as RpcResponse
-  } catch {
-    return {}
+  const contentType = response.headers.get('content-type')?.toLowerCase() ?? ''
+  const raw = await response.text()
+  const diagnostic = raw.replace(/\s+/g, ' ').trim().slice(0, RESPONSE_DIAGNOSTIC_LIMIT)
+
+  if (!contentType.includes('application/json')) {
+    const mediaType = contentType.split(';', 1)[0] || 'an unknown content type'
+    throw new RemoteProtocolError(
+      `Remote host returned ${mediaType} instead of JSON (HTTP ${response.status})${diagnostic ? `: ${diagnostic}` : ''}`,
+    )
   }
+
+  try {
+    return JSON.parse(raw) as RpcResponse
+  } catch (error) {
+    throw new RemoteProtocolError(
+      `Remote host returned invalid JSON (HTTP ${response.status})${diagnostic ? `: ${diagnostic}` : ''}`,
+      { cause: error },
+    )
+  }
+}
+
+function hostnameMismatchMessage(baseUrl: string): string {
+  const hostname = new URL(baseUrl).hostname
+  return `The remote host rejected hostname "${hostname}". Use a URL whose hostname matches the remote server bind host.`
+}
+
+function isTransportError(error: unknown): boolean {
+  return error instanceof TypeError || (error instanceof DOMException && error.name === 'AbortError')
 }
 
 export class RemoteControlClient {
   private eventAbort: AbortController | null = null
   private reconnectTimer: NodeJS.Timeout | null = null
   private streamGeneration = 0
+  private unavailable: { hostId: string; error: RemoteUnavailableError } | null = null
+  private reconnectAttempt = 0
 
   constructor(private readonly window: BrowserWindow) {
     this.restartEventStream()
@@ -195,6 +245,7 @@ export class RemoteControlClient {
   async invokeIfActive(channel: string, args: unknown[]): Promise<ProxyResult> {
     const host = this.getActiveHost()
     if (!host || !this.shouldProxy(channel)) return { handled: false }
+    if (this.unavailable?.hostId === host.id) throw this.unavailable.error
     return { handled: true, value: await this.invoke(host, channel, args) }
   }
 
@@ -211,6 +262,7 @@ export class RemoteControlClient {
         })
         const body = await readJsonResponse(response)
         if (response.ok && body.ok) return { ok: true }
+        if (response.status === 421) return { ok: false, error: hostnameMismatchMessage(normalized.baseUrl) }
         return { ok: false, error: body.error ?? `HTTP ${response.status}` }
       } finally {
         clearTimeout(timer)
@@ -221,19 +273,33 @@ export class RemoteControlClient {
   }
 
   private async invoke(host: RemoteHost, channel: string, args: unknown[]): Promise<unknown> {
-    const response = await fetch(endpoint(host.baseUrl, '/api/remote/rpc'), {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${host.token}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ channel, args }),
-    })
-    const body = await readJsonResponse(response)
-    if (!response.ok || !body.ok) {
-      throw new Error(body.error ?? `Remote request failed with HTTP ${response.status}`)
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), RPC_TIMEOUT_MS)
+    try {
+      const response = await fetch(endpoint(host.baseUrl, '/api/remote/rpc'), {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${host.token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ channel, args }),
+        signal: controller.signal,
+      })
+      const body = await readJsonResponse(response)
+      if (response.status === 421) {
+        throw this.markUnavailable(host, hostnameMismatchMessage(host.baseUrl))
+      }
+      if (!response.ok || !body.ok) {
+        throw new Error(body.error ?? `Remote request failed with HTTP ${response.status}`)
+      }
+      this.markAvailable(host.id)
+      return body.value
+    } catch (error) {
+      if (!isTransportError(error)) throw error
+      throw this.markUnavailable(host, controller.signal.aborted ? 'Remote host request timed out' : errorMessage(error), error)
+    } finally {
+      clearTimeout(timer)
     }
-    return body.value
   }
 
   private restartEventStream(): void {
@@ -244,6 +310,8 @@ export class RemoteControlClient {
     }
     this.eventAbort?.abort()
     this.eventAbort = null
+    this.unavailable = null
+    this.reconnectAttempt = 0
 
     const host = this.getActiveHost()
     if (!host) return
@@ -278,6 +346,8 @@ export class RemoteControlClient {
         throw new Error(`Remote event stream failed with HTTP ${response.status}`)
       }
 
+      this.markAvailable(host.id)
+
       const reader = response.body.getReader()
       const decoder = new TextDecoder()
       let buffer = ''
@@ -296,14 +366,36 @@ export class RemoteControlClient {
       }
     } catch (error) {
       if (!controller.signal.aborted) {
+        if (isTransportError(error)) this.markUnavailable(host, errorMessage(error), error)
         console.warn('[remote-control] Event stream disconnected:', errorMessage(error))
       }
     } finally {
       if (this.eventAbort === controller) this.eventAbort = null
       if (generation === this.streamGeneration && !controller.signal.aborted) {
-        this.connectEventStream(host, generation, 2000)
+        const delay = Math.min(
+          RECONNECT_BASE_DELAY_MS * (2 ** this.reconnectAttempt),
+          RECONNECT_MAX_DELAY_MS,
+        )
+        this.reconnectAttempt += 1
+        this.connectEventStream(host, generation, delay)
       }
     }
+  }
+
+  private markUnavailable(host: RemoteHost, detail: string, cause?: unknown): RemoteUnavailableError {
+    if (this.unavailable?.hostId === host.id) return this.unavailable.error
+    const error = new RemoteUnavailableError(
+      host.id,
+      `Remote host "${host.label}" is unavailable: ${detail}`,
+      cause === undefined ? undefined : { cause },
+    )
+    this.unavailable = { hostId: host.id, error }
+    return error
+  }
+
+  private markAvailable(hostId: string): void {
+    if (this.unavailable?.hostId === hostId) this.unavailable = null
+    this.reconnectAttempt = 0
   }
 
   private handleSseFrame(frame: string): void {


### PR DESCRIPTION
## Summary
- open a per-host circuit after remote transport loss and reuse a typed `REMOTE_UNAVAILABLE` error for follow-up calls
- add a 10-second RPC deadline and bounded exponential SSE reconnect backoff
- validate JSON response content types and preserve a bounded invalid-body diagnostic
- turn HTTP 421 health/RPC responses into an actionable hostname mismatch
- cover refused connections, 421 responses, timeouts, HTML-with-200 responses, and proxy channel gating

## Root cause
Remote-capable renderer channels independently called `fetch`, so one lost host produced many concurrent failures. The client also swallowed response parse errors as `{}`, which converted successful non-JSON proxy pages into the misleading `Remote request failed with HTTP 200` message.

## Verification
- `pnpm --filter polycode-electron typecheck`
- `pnpm exec eslint apps/desktop/src/main/remote/client.ts apps/desktop/src/main/__tests__/remote-client-connectivity.test.ts --max-warnings 0`
- `pnpm --filter polycode-electron exec vitest run --project main src/main/__tests__/remote-client-connectivity.test.ts src/main/__tests__/remote-client-should-proxy.test.ts` (8 passed)
- `git diff --check`

The full desktop suite reports 991 passing tests and 9 unrelated existing Windows failures: WSL/SSH runner timeouts and updater test doubles that do not implement `BrowserWindow.isDestroyed()`.

Fixes #30