### PR TITLE
Fix packaging of stale better-sqlite3 native modules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,10 @@ jobs:
           POLYCODE_OTLP_ENDPOINT: https://otlp.biap.cc
           POLYCODE_OTLP_HEADERS: ${{ secrets.POLYCODE_OTLP_HEADERS }}
 
+      - name: Verify packaged native module ABI
+        working-directory: apps/desktop
+        run: pnpm run verify:electron-abi
+
       - name: Build installer and upload draft release
         working-directory: apps/desktop
         run: pnpm exec electron-builder --win --publish always --config.publish.releaseType=draft

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,6 +6,7 @@
   "author": "billpeet",
   "scripts": {
     "electron-abi": "node scripts/postinstall.js",
+    "verify:electron-abi": "node scripts/verify-electron-abi.js",
     "dev": "pnpm run electron-abi && electron-vite dev",
     "build": "electron-vite build",
     "preview": "electron-vite preview",
@@ -13,8 +14,8 @@
     "start:prod": "pnpm run build && pnpm run electron-abi && cross-env NODE_ENV=production electron .",
     "typecheck": "tsc --build --noEmit",
     "test": "pnpm --dir ../../node_modules/better-sqlite3 exec prebuild-install && vitest run",
-    "dist": "pnpm run build && pnpm run electron-abi && electron-builder --win",
-    "dist:publish": "pnpm run build && pnpm run electron-abi && electron-builder --win --publish always"
+    "dist": "pnpm run build && pnpm run electron-abi && pnpm run verify:electron-abi && electron-builder --win",
+    "dist:publish": "pnpm run build && pnpm run electron-abi && pnpm run verify:electron-abi && electron-builder --win --publish always"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.207",

--- a/apps/desktop/scripts/postinstall.js
+++ b/apps/desktop/scripts/postinstall.js
@@ -90,15 +90,22 @@ const abi = `v${abiNumber}`
 // version short-circuit the download.
 const bindingDir = path.join(bsq3Dir, 'lib', 'binding', `node-${abi}-win32-x64`)
 const bindingNode = path.join(bindingDir, 'better_sqlite3.node')
+const buildReleaseDir = path.join(bsq3Dir, 'build', 'Release')
+const genericPrebuilt = path.join(bsq3Dir, 'prebuilds', 'win32-x64')
+
+// These ABI-less locations are the ones packaged by electron-builder and found
+// first by bindings.js. Remove them before selecting the Electron prebuild so a
+// failed preparation can never leave a host-Node binary looking shippable.
+fs.rmSync(buildReleaseDir, { recursive: true, force: true })
+fs.rmSync(genericPrebuilt, { recursive: true, force: true })
 
 if (fs.existsSync(bindingNode)) {
-  // Refresh the generic copies in case they hold a binary for a different ABI
-  const buildReleaseDir = path.join(bsq3Dir, 'build', 'Release')
+  // Refresh the generic copies from the ABI-specific source of truth.
   fs.mkdirSync(buildReleaseDir, { recursive: true })
   fs.copyFileSync(bindingNode, path.join(buildReleaseDir, 'better_sqlite3.node'))
-  const genericPrebuilt = path.join(bsq3Dir, 'prebuilds', 'win32-x64', 'build', 'Release')
-  fs.mkdirSync(genericPrebuilt, { recursive: true })
-  fs.copyFileSync(bindingNode, path.join(genericPrebuilt, 'better_sqlite3.node'))
+  const genericPrebuiltRelease = path.join(genericPrebuilt, 'build', 'Release')
+  fs.mkdirSync(genericPrebuiltRelease, { recursive: true })
+  fs.copyFileSync(bindingNode, path.join(genericPrebuiltRelease, 'better_sqlite3.node'))
   console.log(`[postinstall] better-sqlite3 prebuilt already present (electron ${abi}).`)
   process.exit(0)
 }
@@ -106,7 +113,7 @@ if (fs.existsSync(bindingNode)) {
 const tarball = `better-sqlite3-v${bsq3Version}-electron-${abi}-win32-x64.tar.gz`
 const url = `https://github.com/WiseLibs/better-sqlite3/releases/download/v${bsq3Version}/${tarball}`
 // Two places bindings looks: prebuilds/ and lib/binding/
-const prebuildsDir = path.join(bsq3Dir, 'prebuilds', 'win32-x64')
+const prebuildsDir = genericPrebuilt
 // Download into the extraction dir and extract with cwd set so tar only ever
 // sees a bare filename — GNU tar interprets "C:\..." as a remote host.
 const tmp = path.join(prebuildsDir, tarball)
@@ -130,12 +137,15 @@ downloadFile(url, tmp, (err) => {
   }
   fs.unlinkSync(tmp)
   const src = path.join(prebuildsDir, 'build', 'Release', 'better_sqlite3.node')
+  if (!fs.existsSync(src)) {
+    console.error(`[postinstall] Expected Electron prebuild is missing: ${src}`)
+    process.exit(1)
+  }
   // Copy to lib/binding/ path that bindings.js resolves at runtime
   const dst = path.join(bindingDir, 'better_sqlite3.node')
   fs.copyFileSync(src, dst)
   // Overwrite build/Release/ so the Electron prebuilt wins over any
   // node-gyp artefact compiled against the host Node.js version
-  const buildReleaseDir = path.join(bsq3Dir, 'build', 'Release')
   fs.mkdirSync(buildReleaseDir, { recursive: true })
   fs.copyFileSync(src, path.join(buildReleaseDir, 'better_sqlite3.node'))
   console.log('[postinstall] better-sqlite3 prebuilt installed.')

--- a/apps/desktop/scripts/verify-electron-abi.js
+++ b/apps/desktop/scripts/verify-electron-abi.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('child_process')
+const fs = require('fs')
+const path = require('path')
+
+function resolvePackageDir(name) {
+  try {
+    return path.dirname(require.resolve(`${name}/package.json`, { paths: [__dirname] }))
+  } catch {
+    return null
+  }
+}
+
+const electronDir = resolvePackageDir('electron')
+const betterSqliteDir = resolvePackageDir('better-sqlite3')
+if (!electronDir || !betterSqliteDir) {
+  console.error('[verify-electron-abi] electron or better-sqlite3 is not installed.')
+  process.exit(1)
+}
+
+const electronPathFile = path.join(electronDir, 'path.txt')
+if (!fs.existsSync(electronPathFile)) {
+  console.error('[verify-electron-abi] Electron binary is not installed.')
+  process.exit(1)
+}
+
+const electronExe = path.join(
+  electronDir,
+  'dist',
+  fs.readFileSync(electronPathFile, 'utf8').trim()
+)
+const binding = path.join(betterSqliteDir, 'build', 'Release', 'better_sqlite3.node')
+if (!fs.existsSync(binding)) {
+  console.error(`[verify-electron-abi] Packaged binding is missing: ${binding}`)
+  process.exit(1)
+}
+
+const probe = [
+  "const binding = process.argv[1]",
+  "require(binding)",
+  "process.stdout.write(JSON.stringify({ abi: process.versions.modules, binding }))"
+].join(';')
+const result = spawnSync(electronExe, ['-e', probe, binding], {
+  env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+  encoding: 'utf8'
+})
+
+if (result.status !== 0) {
+  console.error('[verify-electron-abi] Packaged better-sqlite3 binding failed to load in Electron.')
+  if (result.stderr) {
+    const lines = result.stderr.trim().split(/\r?\n/)
+    const mismatch = lines.findIndex((line) => line.includes('was compiled against a different'))
+    console.error(lines.slice(mismatch >= 0 ? mismatch : -12).join('\n'))
+  }
+  process.exit(1)
+}
+
+let output
+try {
+  output = JSON.parse(result.stdout)
+} catch {
+  console.error('[verify-electron-abi] Electron ABI probe returned invalid output.')
+  process.exit(1)
+}
+
+const expectedAbiFile = path.join(electronDir, 'abi_version')
+const expectedAbi = fs.existsSync(expectedAbiFile)
+  ? fs.readFileSync(expectedAbiFile, 'utf8').trim()
+  : output.abi
+if (output.abi !== expectedAbi) {
+  console.error(
+    `[verify-electron-abi] Electron reported ABI ${output.abi}; expected ${expectedAbi}.`
+  )
+  process.exit(1)
+}
+
+console.log(
+  `[verify-electron-abi] Packaged better-sqlite3 binding loads successfully under Electron ABI ${output.abi}.`
+)


### PR DESCRIPTION
## Summary
- remove stale ABI-less better-sqlite3 outputs before preparing the Electron prebuild
- fail closed when the expected Electron native artifact is absent
- load the exact `build/Release/better_sqlite3.node` packaging candidate under Electron before electron-builder runs
- enforce the ABI verification in local distribution scripts and release CI

## Root cause
With `npmRebuild: false`, electron-builder packages the existing native artifact. A host-Node binary could remain in the generic `build/Release` path that bindings resolves first, even when an Electron-specific copy existed elsewhere. The release pipeline had no assertion that the selected binary could load under Electron.

## Verification
- reproduced the startup failure by installing the host Node ABI 127 prebuild: verifier rejected it because Electron requires ABI 140
- reran native preparation: verifier loaded the packaged candidate successfully under Electron ABI 140
- targeted ESLint passed
- TypeScript build check passed
- desktop suite: 1,004 passed; one pre-existing environment-dependent WSL detection hook timed out after 10 seconds (14 runner tests skipped)

Closes #32