### PR TITLE
Recover missed events on reconnect, measure latency, signal slow remote calls

### DIFF
--- a/apps/desktop/src/main/__tests__/remote-client-connectivity.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-client-connectivity.test.ts
@@ -256,6 +256,33 @@ describe('RemoteControlClient connectivity failures', () => {
     client.stop()
   })
 
+  it('probes host latency and publishes it on the connection state', async () => {
+    vi.useFakeTimers()
+    H.fetch.mockImplementation((url) => {
+      if (String(url).endsWith('/api/remote/health')) {
+        return Promise.resolve(jsonResponse(200, { ok: true, app: 'polycode', version: '1.0.0' }))
+      }
+      return Promise.resolve(openEventStream())
+    })
+    const client = healthyClient()
+    await vi.advanceTimersByTimeAsync(0)
+
+    const latencies = H.appEvents
+      .filter((event) => event.channel === 'remote:connection-changed')
+      .map((event) => (event.args[0] as { latencyMs: number | null }).latencyMs)
+    // The immediate probe after connect publishes a reading (0ms under fake timers).
+    expect(latencies.at(-1)).toBe(0)
+    expect(client.getConnectionState().phase).toBe('connected')
+
+    // Subsequent probes fire on the 30s interval without a phase transition.
+    const healthCalls = () =>
+      H.fetch.mock.calls.filter(([url]) => String(url).endsWith('/api/remote/health')).length
+    const before = healthCalls()
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(healthCalls()).toBe(before + 1)
+    client.stop()
+  })
+
   it('reports the open circuit as an unavailable connection state', async () => {
     H.fetch.mockRejectedValue(new TypeError('fetch failed'))
     const client = activeClient()

--- a/apps/desktop/src/main/remote/client.ts
+++ b/apps/desktop/src/main/remote/client.ts
@@ -3,6 +3,7 @@ import { BrowserWindow, powerMonitor } from 'electron'
 import { isRemoteChannel } from '@polycode/shared'
 import { getSetting, setSetting } from '../db/queries'
 import { emitAppEvent, sendToRenderer } from '../app-events'
+import { count, recordDuration } from '../observability'
 import {
   RemoteConnectionState,
   RemoteConnectionStatus,
@@ -45,6 +46,12 @@ const RECONNECT_MAX_DELAY_MS = 30_000
 // without this watchdog `streamConnected` would stay true forever and no reconnect fires.
 const STREAM_STALL_TIMEOUT_MS = 60_000
 const STREAM_STALL_CHECK_INTERVAL_MS = 15_000
+// Lightweight GET /api/remote/health round trip, published as `latencyMs` on the
+// connection state so the UI can show how far away the host actually is.
+const LATENCY_PROBE_INTERVAL_MS = 30_000
+const LATENCY_PROBE_TIMEOUT_MS = 5_000
+// Ignore sub-jitter changes so the probe doesn't emit a connection-changed every 30s.
+const LATENCY_EMIT_DELTA_MS = 15
 
 export class RemoteUnavailableError extends Error {
   readonly code = 'REMOTE_UNAVAILABLE'
@@ -186,8 +193,11 @@ export class RemoteControlClient {
     phase: 'local',
     reconnectAttempt: 0,
     error: null,
+    latencyMs: null,
     changedAt: new Date().toISOString(),
   }
+  private latencyMs: number | null = null
+  private latencyTimer: NodeJS.Timeout | null = null
   /**
    * OS sleep is the canonical way to half-open the SSE stream's TCP connection. The stall
    * watchdog would notice within a minute; restarting on resume closes the gap immediately.
@@ -203,6 +213,7 @@ export class RemoteControlClient {
 
   stop(): void {
     powerMonitor.off('resume', this.handleResume)
+    this.stopLatencyProbe()
     this.streamGeneration += 1
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer)
@@ -224,7 +235,7 @@ export class RemoteControlClient {
   }
 
   private setConnectionState(
-    next: Omit<RemoteConnectionState, 'changedAt' | 'hostId'> & { hostId?: string | null },
+    next: Omit<RemoteConnectionState, 'changedAt' | 'hostId' | 'latencyMs'> & { hostId?: string | null },
   ): void {
     const hostId = next.hostId !== undefined ? next.hostId : this.getActiveHost()?.id ?? null
     const current = this.connectionState
@@ -233,15 +244,66 @@ export class RemoteControlClient {
       && current.phase === next.phase
       && current.reconnectAttempt === next.reconnectAttempt
       && current.error === next.error
+      && current.latencyMs === this.latencyMs
     ) return
     this.connectionState = {
       hostId,
       phase: next.phase,
       reconnectAttempt: next.reconnectAttempt,
       error: next.error,
+      latencyMs: this.latencyMs,
       changedAt: new Date().toISOString(),
     }
     emitAppEvent(this.window, 'remote:connection-changed', this.connectionState)
+  }
+
+  /** Re-emit the current state with a fresh latency reading, without a phase transition. */
+  private publishLatency(latencyMs: number): void {
+    const previous = this.latencyMs
+    this.latencyMs = latencyMs
+    if (previous !== null && Math.abs(previous - latencyMs) < LATENCY_EMIT_DELTA_MS) return
+    const { hostId, phase, reconnectAttempt, error } = this.connectionState
+    this.setConnectionState({ hostId, phase, reconnectAttempt, error })
+  }
+
+  private startLatencyProbe(host: RemoteHost): void {
+    this.stopLatencyProbe()
+    const probe = (): void => void this.probeLatency(host)
+    this.latencyTimer = setInterval(probe, LATENCY_PROBE_INTERVAL_MS)
+    probe()
+  }
+
+  private stopLatencyProbe(): void {
+    if (this.latencyTimer) {
+      clearInterval(this.latencyTimer)
+      this.latencyTimer = null
+    }
+  }
+
+  private async probeLatency(host: RemoteHost): Promise<void> {
+    // The probe only reports how far away a *reachable* host is. When the circuit is open
+    // or the stream is down, the watchdog and RPC paths own the failure story.
+    if (!this.streamConnected || this.unavailable?.hostId === host.id) return
+    if (this.getActiveHost()?.id !== host.id) return
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), LATENCY_PROBE_TIMEOUT_MS)
+    const startedAt = Date.now()
+    try {
+      const response = await fetch(endpoint(host.baseUrl, '/api/remote/health'), {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${host.token}` },
+        signal: controller.signal,
+      })
+      if (!response.ok) return
+      await response.text()
+      const latencyMs = Date.now() - startedAt
+      recordDuration('polycode.remote.health.rtt', latencyMs, { 'remote.host': host.label })
+      this.publishLatency(latencyMs)
+    } catch {
+      // A failed probe is not a connectivity verdict — the stall watchdog is.
+    } finally {
+      clearTimeout(timer)
+    }
   }
 
   getHosts(): RemoteHost[] {
@@ -358,6 +420,10 @@ export class RemoteControlClient {
     const controller = new AbortController()
     const timeoutMs = SLOW_RPC_CHANNELS.has(channel) ? SLOW_RPC_TIMEOUT_MS : RPC_TIMEOUT_MS
     const timer = setTimeout(() => controller.abort(), timeoutMs)
+    const startedAt = Date.now()
+    // Remote round trips were previously invisible in telemetry: perf.ts times the outer
+    // ipcMain.handle span, where a proxied call just looks like a slow local one.
+    let outcome = 'ok'
     try {
       const response = await fetch(endpoint(host.baseUrl, '/api/remote/rpc'), {
         method: 'POST',
@@ -378,7 +444,11 @@ export class RemoteControlClient {
       this.markAvailable(host.id)
       return body.value
     } catch (error) {
-      if (!isTransportError(error)) throw error
+      if (!isTransportError(error)) {
+        outcome = 'error'
+        throw error
+      }
+      outcome = controller.signal.aborted && this.streamConnected ? 'timeout' : 'unavailable'
       if (controller.signal.aborted && this.streamConnected) {
         // The event stream to the same host is open, so this is not transport loss — the
         // request simply outlived its budget and may still be running host-side. Throwing
@@ -392,6 +462,10 @@ export class RemoteControlClient {
       throw this.markUnavailable(host, controller.signal.aborted ? 'Remote host request timed out' : errorMessage(error), error)
     } finally {
       clearTimeout(timer)
+      recordDuration('polycode.remote.rpc.duration', Date.now() - startedAt, {
+        'rpc.channel': channel,
+        'rpc.outcome': outcome,
+      })
     }
   }
 
@@ -405,6 +479,9 @@ export class RemoteControlClient {
     this.eventAbort = null
     this.unavailable = null
     this.reconnectAttempt = 0
+
+    this.stopLatencyProbe()
+    this.latencyMs = null
 
     const host = this.getActiveHost()
     if (!host) {
@@ -461,6 +538,7 @@ export class RemoteControlClient {
       this.markAvailable(host.id)
       this.streamConnected = true
       this.setConnectionState({ hostId: host.id, phase: 'connected', reconnectAttempt: 0, error: null })
+      this.startLatencyProbe(host)
 
       const reader = response.body.getReader()
       const decoder = new TextDecoder()
@@ -500,6 +578,7 @@ export class RemoteControlClient {
           RECONNECT_MAX_DELAY_MS,
         )
         this.reconnectAttempt += 1
+        count('polycode.remote.stream.reconnect', { 'reconnect.reason': stalled ? 'stall' : 'drop' })
         this.setConnectionState({
           hostId: host.id,
           phase: this.unavailable?.hostId === host.id ? 'unavailable' : 'reconnecting',

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -4,6 +4,45 @@ import { getHeapStatistics } from 'node:v8'
 
 export type IpcListener = (...args: unknown[]) => void
 
+// ── Slow-invoke signal ───────────────────────────────────────────────────────
+//
+// Every request/response call already flows through api.invoke, which makes this the one
+// place that can cheaply notice "something the UI asked for is taking a while". Listeners
+// get the number of calls currently in flight past the threshold; the renderer decides
+// whether that means anything (it only surfaces the signal while a remote host is active,
+// where the delay is network distance rather than local work).
+const SLOW_INVOKE_THRESHOLD_MS = 400
+
+type SlowInvokeListener = (pendingSlowCalls: number) => void
+const slowInvokeListeners = new Set<SlowInvokeListener>()
+let pendingSlowCalls = 0
+
+function notifySlowInvoke(): void {
+  for (const listener of slowInvokeListeners) {
+    try {
+      listener(pendingSlowCalls)
+    } catch {
+      // A broken listener must not take down IPC timing for everyone else.
+    }
+  }
+}
+
+function trackSlowInvoke(promise: Promise<unknown>): void {
+  let counted = false
+  const timer = setTimeout(() => {
+    counted = true
+    pendingSlowCalls += 1
+    notifySlowInvoke()
+  }, SLOW_INVOKE_THRESHOLD_MS)
+  void promise.finally(() => {
+    clearTimeout(timer)
+    if (counted) {
+      pendingSlowCalls -= 1
+      notifySlowInvoke()
+    }
+  }).catch(() => undefined)
+}
+
 const api = {
   /**
    * Request/response calls are allowlisted from the channel registry, which makes it a
@@ -21,7 +60,9 @@ const api = {
       )
     }
     const startedAt = performance.now()
-    return ipcRenderer.invoke(channel, ...args).finally(() => {
+    const pending = ipcRenderer.invoke(channel, ...args)
+    trackSlowInvoke(pending)
+    return pending.finally(() => {
       const durationMs = performance.now() - startedAt
       if (durationMs >= 50) {
         ipcRenderer.send('log:write', {
@@ -43,6 +84,15 @@ const api = {
 
   send(channel: string, ...args: unknown[]): void {
     ipcRenderer.send(channel, ...args)
+  },
+
+  /**
+   * Subscribe to the count of invoke calls currently in flight past the slow threshold.
+   * Fires only on transitions (a call crossing the threshold, or such a call settling).
+   */
+  onSlowInvoke(callback: (pendingSlowCalls: number) => void): () => void {
+    slowInvokeListeners.add(callback)
+    return () => slowInvokeListeners.delete(callback)
   }
 }
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -27,6 +27,7 @@ import { reportReactCommit } from './lib/perf'
 import { getCurrentLocationId } from './lib/currentLocation'
 import UiErrorBoundary from './components/UiErrorBoundary'
 import { useDatabaseSync } from './hooks/useDatabaseSync'
+import { useRemoteConnectionStore } from './stores/remoteConnection'
 import { writeClipboardText } from './lib/clipboard'
 
 const SETTING_PROJECT_KEY = 'selectedProjectId'
@@ -364,6 +365,15 @@ export default function App() {
       void fetchProjects()
     })
   }, [fetchProjects])
+
+  // Stream recovery: SSE has no replay, so thread status/queue pushes emitted while the
+  // remote event stream was down never arrived. ThreadView refetches the open thread on
+  // this nonce; the queue is the other push-driven surface and is reconciled here.
+  const reconnectNonce = useRemoteConnectionStore((s) => s.reconnectNonce)
+  useEffect(() => {
+    if (reconnectNonce === 0) return
+    void useThreadStore.getState().fetchQueue()
+  }, [reconnectNonce])
 
   // 4. Persist selections whenever they change
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/components/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/components/ThreadView.tsx
@@ -14,6 +14,7 @@ import MessageStream from './MessageStream'
 import InputBar from './InputBar'
 import { formatErrorDetails } from '../lib/errorDetails'
 import UiErrorBoundary from './UiErrorBoundary'
+import { useRemoteConnectionStore } from '../stores/remoteConnection'
 
 interface Props {
   threadId: string
@@ -57,18 +58,24 @@ function ThreadViewContent({ threadId }: Props) {
 
   const cleanupRef = useRef<Array<() => void>>([])
 
+  // Desktop SSE has no replay: any thread:output/status/complete emitted while the remote
+  // event stream was down is simply gone. Re-keying the fetch effects below on this nonce
+  // makes a stream recovery behave like a remount — transcript, sessions and canonical
+  // status are refetched, so a thread can't be left visually "running" forever.
+  const reconnectNonce = useRemoteConnectionStore((s) => s.reconnectNonce)
+
   // Fetch sessions when thread changes
   useEffect(() => {
     if (isPendingThread) return
     fetchSessions(threadId)
-  }, [threadId, fetchSessions, isPendingThread])
+  }, [threadId, fetchSessions, isPendingThread, reconnectNonce])
 
   // Reconcile canonical status when a thread view mounts. Per-thread push
   // events can be missed while another thread is selected.
   useEffect(() => {
     if (isPendingThread || !threadProjectId) return
     void fetchThreads(threadProjectId)
-  }, [fetchThreads, isPendingThread, threadProjectId])
+  }, [fetchThreads, isPendingThread, threadProjectId, reconnectNonce])
 
   // Fetch messages when active session changes, and sync todos from persisted messages
   useEffect(() => {
@@ -85,7 +92,7 @@ function ThreadViewContent({ threadId }: Props) {
       }
     }
     doFetch()
-  }, [threadId, activeSessionId, fetchMessages, fetchMessagesBySession, isPendingThread])
+  }, [threadId, activeSessionId, fetchMessages, fetchMessagesBySession, isPendingThread, reconnectNonce])
 
   useEffect(() => {
     if (isPendingThread) return

--- a/apps/desktop/src/renderer/src/components/TitleBar.tsx
+++ b/apps/desktop/src/renderer/src/components/TitleBar.tsx
@@ -15,6 +15,7 @@ export default function TitleBar() {
   const [hosts, setHosts] = useState<RemoteHost[]>([])
   const [activeHost, setActiveHost] = useState<RemoteHost | null>(null)
   const connection = useRemoteConnectionStore((s) => s.connection)
+  const slowCalls = useRemoteConnectionStore((s) => s.slowCalls)
 
   useEffect(() => {
     initRemoteConnectionStore()
@@ -108,19 +109,31 @@ export default function TitleBar() {
         </span>
         {activeHost && (() => {
           const dot = PHASE_DOT[connection.phase]
-          const title = connection.error ? `${dot.label} — ${connection.error}` : dot.label
+          const latency = connection.phase === 'connected' && connection.latencyMs !== null
+            ? `${Math.round(connection.latencyMs)}ms`
+            : null
+          const title = [
+            latency ? `${dot.label} · ${latency}` : dot.label,
+            connection.error,
+          ].filter(Boolean).join(' — ')
           return (
-            <span
-              title={title}
-              className={dot.pulse ? 'animate-pulse' : undefined}
-              style={{
-                width: 8,
-                height: 8,
-                borderRadius: '50%',
-                background: dot.color,
-                flexShrink: 0,
-              }}
-            />
+            <span title={title} style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0 }}>
+              <span
+                className={dot.pulse ? 'animate-pulse' : undefined}
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: '50%',
+                  background: dot.color,
+                  flexShrink: 0,
+                }}
+              />
+              {latency && (
+                <span style={{ fontSize: 10, color: 'var(--color-text-muted)', userSelect: 'none' }}>
+                  {latency}
+                </span>
+              )}
+            </span>
           )
         })()}
         <select
@@ -146,6 +159,20 @@ export default function TitleBar() {
             </option>
           ))}
         </select>
+        {/*
+          Perceived-latency signal: at least one in-flight IPC call has been waiting on the
+          remote host past the preload's slow threshold. One subtle global spinner instead
+          of per-component ones — the delay is network distance, not any single view's work.
+          Only rendered while remote is active; local slow calls mean local work, and the
+          offline/reconnecting states already have the banner.
+        */}
+        {activeHost && slowCalls > 0 && connection.phase === 'connected' && (
+          <span
+            className="status-spinner"
+            title={`Waiting for remote host (${slowCalls} slow ${slowCalls === 1 ? 'request' : 'requests'})…`}
+            style={{ width: 10, height: 10, flexShrink: 0 }}
+          />
+        )}
       </div>
 
       <div style={{ flex: 1 }} />

--- a/apps/desktop/src/renderer/src/stores/__tests__/remoteConnection.test.ts
+++ b/apps/desktop/src/renderer/src/stores/__tests__/remoteConnection.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { isReconnectRecovery } from '../remoteConnection'
+import type { RemoteConnectionState } from '../../types/ipc'
+
+function state(overrides: Partial<RemoteConnectionState>): RemoteConnectionState {
+  return {
+    hostId: 'host-1',
+    phase: 'connected',
+    reconnectAttempt: 0,
+    error: null,
+    latencyMs: null,
+    changedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('isReconnectRecovery', () => {
+  it('detects reconnecting → connected on the same host', () => {
+    expect(isReconnectRecovery(state({ phase: 'reconnecting' }), state({}))).toBe(true)
+  })
+
+  it('detects unavailable → connected on the same host', () => {
+    expect(isReconnectRecovery(state({ phase: 'unavailable' }), state({}))).toBe(true)
+  })
+
+  it('ignores the initial connect after activating a host', () => {
+    // active-changed already resets and refetches everything; bumping the nonce here would
+    // double-fetch every mount.
+    expect(isReconnectRecovery(state({ phase: 'connecting' }), state({}))).toBe(false)
+    expect(isReconnectRecovery(state({ phase: 'local', hostId: null }), state({}))).toBe(false)
+  })
+
+  it('ignores a connect against a different host than the one that dropped', () => {
+    expect(isReconnectRecovery(
+      state({ phase: 'reconnecting', hostId: 'host-1' }),
+      state({ hostId: 'host-2' }),
+    )).toBe(false)
+  })
+
+  it('ignores latency-only re-emissions while connected', () => {
+    expect(isReconnectRecovery(state({}), state({ latencyMs: 42 }))).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/stores/remoteConnection.ts
+++ b/apps/desktop/src/renderer/src/stores/remoteConnection.ts
@@ -5,6 +5,16 @@ interface RemoteConnectionStore {
   connection: RemoteConnectionState
   /** True while a user-initiated retry is in flight. */
   retrying: boolean
+  /**
+   * Bumped when the event stream recovers after a gap (reconnecting/unavailable →
+   * connected). SSE has no replay, so anything the host emitted during the gap is gone;
+   * views that render pushed data re-key their fetch effects on this nonce to catch up.
+   * The initial connect after activating a host does NOT bump it — `remote:active-changed`
+   * already resets and refetches everything.
+   */
+  reconnectNonce: number
+  /** Number of in-flight IPC calls past the preload's slow threshold. */
+  slowCalls: number
   retry: () => Promise<void>
 }
 
@@ -13,12 +23,26 @@ const INITIAL: RemoteConnectionState = {
   phase: 'local',
   reconnectAttempt: 0,
   error: null,
+  latencyMs: null,
   changedAt: new Date(0).toISOString(),
+}
+
+/** Whether moving from `previous` to `next` is a stream recovery that may have lost events. */
+export function isReconnectRecovery(
+  previous: RemoteConnectionState,
+  next: RemoteConnectionState,
+): boolean {
+  return next.phase === 'connected'
+    && next.hostId !== null
+    && next.hostId === previous.hostId
+    && (previous.phase === 'reconnecting' || previous.phase === 'unavailable')
 }
 
 export const useRemoteConnectionStore = create<RemoteConnectionStore>((set) => ({
   connection: INITIAL,
   retrying: false,
+  reconnectNonce: 0,
+  slowCalls: 0,
 
   retry: async () => {
     set({ retrying: true })
@@ -45,7 +69,16 @@ export function initRemoteConnectionStore(): void {
 
   window.api.on('remote:connection-changed', (...args) => {
     const connection = args[0] as RemoteConnectionState | undefined
-    if (connection) useRemoteConnectionStore.setState({ connection })
+    if (!connection) return
+    useRemoteConnectionStore.setState((s) => ({
+      connection,
+      reconnectNonce: isReconnectRecovery(s.connection, connection)
+        ? s.reconnectNonce + 1
+        : s.reconnectNonce,
+    }))
+  })
+  window.api.onSlowInvoke((pendingSlowCalls) => {
+    useRemoteConnectionStore.setState({ slowCalls: pendingSlowCalls })
   })
   void window.api.invoke('remote:getConnectionState')
     .then((connection) => useRemoteConnectionStore.setState({ connection }))

--- a/apps/desktop/src/renderer/src/types/ipc.ts
+++ b/apps/desktop/src/renderer/src/types/ipc.ts
@@ -13,6 +13,7 @@ export interface WindowApi {
 
   on(channel: string, callback: (...args: unknown[]) => void): () => void
   send(channel: string, ...args: unknown[]): void
+  onSlowInvoke(callback: (pendingSlowCalls: number) => void): () => void
 }
 
 declare global {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -136,6 +136,11 @@ export interface RemoteConnectionState {
   reconnectAttempt: number
   /** Human-readable reason when the host is unreachable, otherwise null. */
   error: string | null
+  /**
+   * Round-trip time of the most recent health probe against the active host, in
+   * milliseconds. Null until the first probe answers, and reset on host change.
+   */
+  latencyMs: number | null
   /** ISO timestamp of the transition into this state. */
   changedAt: string
 }


### PR DESCRIPTION
Follow-up to #49 — items 3–5 of the remote-UX plan.

## 3. Missed-event recovery
Desktop SSE has no replay: anything the host emitted while the stream was down (`thread:output`, `thread:complete`, status changes) was silently lost, which could leave a thread visually "running" forever.

- The `remoteConnection` store now bumps a `reconnectNonce` when the stream *recovers* (`reconnecting`/`unavailable` → `connected` on the same host — extracted as pure `isReconnectRecovery` for testing).
- `ThreadView` re-keys its sessions / canonical-status / messages fetch effects on the nonce, so a recovery behaves like a remount; `App` reconciles the queue (the other push-driven surface).
- The initial connect after activating a host deliberately does **not** bump it — `remote:active-changed` already resets and refetches everything.

## 4. Latency measurement & display
- `RemoteControlClient` probes `GET /api/remote/health` every 30s while the stream is up (plus once on connect) and publishes `latencyMs` on `RemoteConnectionState`; emissions are gated to ≥15ms deltas so the probe doesn't chatter. Probe failures are not a connectivity verdict — the stall watchdog owns that.
- TitleBar shows the reading next to the status dot (e.g. green dot · `45ms`) with detail in the tooltip.
- New telemetry, since remote round trips previously just looked like slow local IPC in `perf.ts`: `polycode.remote.rpc.duration` (per channel + ok/timeout/unavailable/error outcome), `polycode.remote.health.rtt`, and `polycode.remote.stream.reconnect` (stall vs drop).

## 5. Perceived-latency signal
- Preload — the one choke point every `invoke` flows through — tracks calls in flight past 400ms and exposes `api.onSlowInvoke(cb)` (transition-only notifications).
- While a remote host is connected and ≥1 call is past the threshold, TitleBar shows a single subtle spinner with a "Waiting for remote host…" tooltip — one global signal for network distance instead of per-component spinners. Local mode ignores the signal; the offline/reconnecting states already have the banner from #49.

## Tests
- Client: latency probe publishes on connect and re-probes on the 30s interval.
- Store: `isReconnectRecovery` matrix (recovery vs initial connect vs host switch vs latency-only re-emission).
- Full desktop suite green (1093 tests) + desktop/shared typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)