### PR TITLE
perf: stop the background git storm (watcher throttle + TTL + direct git spawn)

### DIFF
--- a/apps/desktop/src/main/__tests__/dispatch-characterisation.test.ts
+++ b/apps/desktop/src/main/__tests__/dispatch-characterisation.test.ts
@@ -130,13 +130,12 @@ const H = vi.hoisted(() => {
      */
     execFileFails: false,
     /**
-     * The third argument `git:watchStart` hands `startRepoGitWatch` — the invalidation
-     * callback the watcher fires on every repo change.
-     *
-     * Captured as a value rather than logged because the recorder renders a function as an
-     * empty slot (`JSON.stringify(fn)` is `undefined`), so the call log alone cannot tell
-     * `invalidateRepoGitCache` from any other function, nor from the `undefined` a *call*
-     * would leave in that slot.
+     * The third argument `git:watchStart` hands `startRepoGitWatch`. Historically this was
+     * the `invalidateRepoGitCache` callback; it is now asserted *absent* — the watcher
+     * wiping the git read cache on every filesystem change is the bug that disabled the
+     * status TTL during agent runs. Captured as a value because the recorder renders a
+     * function (and `undefined`) as an empty slot, so the call log alone cannot tell them
+     * apart.
      */
     repoWatchCallback: null as unknown,
   }
@@ -450,10 +449,10 @@ vi.mock('../file-watch', () => H.autoModule('fileWatch', {
   startFileWatch: H.stub('fileWatch.startFileWatch', true),
   // Sentinel for a `: void` callee — see "handlers pass the callee's result through".
   stopFileWatch: H.stub('fileWatch.stopFileWatch', 'RET_stopFileWatch'),
-  // The repo watcher behind `git:watchStart`. It captures its `onChanged` argument so the
-  // callback's *identity* is assertable — see `H.state.repoWatchCallback`.
+  // The repo watcher behind `git:watchStart`. It captures a would-be third argument so the
+  // test can assert no invalidation callback is wired — see `H.state.repoWatchCallback`.
   startRepoGitWatch: H.stub('fileWatch.startRepoGitWatch', (...args: unknown[]) => {
-    H.state.repoWatchCallback = args[2]
+    H.state.repoWatchCallback = args.length > 2 ? args[2] : undefined
     return true
   }),
   // Sentinel for a `: void` callee — see "handlers pass the callee's result through".
@@ -2506,27 +2505,22 @@ describe('git:* — the reads, and the three mutations that sit among them', () 
     ])
   })
 
-  it('git:watchStart hands the window and the invalidation callback to the watcher', async () => {
-    // `invalidateRepoGitCache` is passed as a *reference*, not a call: the watcher fires it
-    // on every repo change it sees. Calling it here instead would invalidate once,
-    // immediately, and leave the watcher with `undefined` — and the recorded call would look
-    // almost identical, because the recorder renders a function argument as an empty slot.
-    // Hence the identity assertion, and the "no invalidateGitCache" one.
-    const { invalidateRepoGitCache } = await import('../ipc/thread-context')
-
+  it('git:watchStart hands the window — and no invalidation callback — to the watcher', async () => {
+    // The watcher used to receive `invalidateRepoGitCache` and fire it on every filesystem
+    // change, which wiped the 5s status TTL continuously during agent runs (see the handler
+    // comment). The callback's *absence* is now the pinned behaviour: the stub captures a
+    // would-be third argument, and there must not be one.
     const ipc = await viaIpc('git:watchStart', ['C:/repo'])
     const ipcCallback = H.state.repoWatchCallback
     const rpc = await viaControlRpc('git:watchStart', ['C:/repo'])
 
     expect(rpc).toEqual(ipc)
-    // The trailing comma inside the brackets is the callback's slot: present, but rendered
-    // empty because `JSON.stringify(fn)` is `undefined`. Its presence pins the argument
-    // count and order; `ipcCallback` below pins which function it is.
-    expect(ipc).toEqual([`fileWatch.startRepoGitWatch([${JSON.stringify(window)},"C:/repo",])`])
+    // Two arguments only: window and path. No trailing callback slot.
+    expect(ipc).toEqual([`fileWatch.startRepoGitWatch([${JSON.stringify(window)},"C:/repo"])`])
     // Both transports resolve the same BrowserWindow — the IPC path closed over the one
     // `registerIpcHandlers` was given, the control-RPC path took it as a parameter.
-    expect(ipcCallback).toBe(invalidateRepoGitCache)
-    expect(H.state.repoWatchCallback).toBe(invalidateRepoGitCache)
+    expect(ipcCallback).toBeUndefined()
+    expect(H.state.repoWatchCallback).toBeUndefined()
     // Keyed on the path alone: no getConfigForPath, and nothing invalidated up front.
     expect(ipc.some((entry) => entry.includes('getLocationByPath'))).toBe(false)
     expect(ipc.some((entry) => entry.includes('invalidateGitCache'))).toBe(false)

--- a/apps/desktop/src/main/driver/runner/local.ts
+++ b/apps/desktop/src/main/driver/runner/local.ts
@@ -6,6 +6,17 @@ import { Runner, RunCommand, RunResult, RunScriptCommand, ScriptCommand, SpawnCo
 import { winQuote, augmentWindowsPath, getCmdExe, getPowerShellExe } from './utils'
 import { collectProcess } from './collect'
 
+/**
+ * Binaries safe to spawn without cmd.exe on Windows. Bare names resolve via CreateProcess's
+ * PATH search, which finds .exe but not .cmd/.bat shims — so this list is conservative:
+ * `git` (always git.exe) and anything the caller already resolved to an explicit .exe path.
+ * Everything else keeps the shell so npm-style .cmd wrappers continue to work.
+ */
+function isDirectWindowsExecutable(binary: string): boolean {
+  const lower = binary.toLowerCase()
+  return lower === 'git' || lower.endsWith('.exe')
+}
+
 export class LocalRunner implements Runner {
   readonly type = 'local' as const
 
@@ -74,6 +85,25 @@ export class LocalRunner implements Runner {
           stdio: ['pipe', 'pipe', 'pipe'],
         })
         proc.on('close', () => { try { unlinkSync(batchPath) } catch { /* ignore */ } })
+        if (stdinContent !== undefined) {
+          proc.stdin?.write(stdinContent)
+        }
+        if (!keepStdinOpen) proc.stdin?.end()
+        return proc
+      } else if (isDirectWindowsExecutable(binary)) {
+        // Real .exe binaries don't need cmd.exe: shell:true exists solely for npm-style
+        // .cmd wrappers. Routing git through the shell doubled the process count on the
+        // hottest spawn path in the app (cmd.exe + git.exe per invocation, ~100ms floor —
+        // Grafana showed git:head p50 at 101ms for what is a ~10ms rev-parse) and forced
+        // hand-rolled winQuote quoting. Direct spawn passes args verbatim.
+        console.log('[LocalRunner] Spawning (Windows/direct):', binary, args.join(' '))
+        const proc = spawn(binary, args, {
+          cwd: workDir,
+          env,
+          shell: false,
+          windowsHide: true,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        })
         if (stdinContent !== undefined) {
           proc.stdin?.write(stdinContent)
         }

--- a/apps/desktop/src/main/file-watch.ts
+++ b/apps/desktop/src/main/file-watch.ts
@@ -18,6 +18,23 @@ interface RepoWatchEntry {
 const watchers = new Map<string, FileWatchEntry>()
 const repoWatchers = new Map<string, RepoWatchEntry>()
 
+/**
+ * Trailing-throttle window for `git:repoChanged`. The old behaviour was a resettable 1s
+ * debounce: during an active agent run the worktree is written continuously, so the debounce
+ * either never settled or fired every ~1.75s forever — the renderer then ran its
+ * isRepo→status→head refresh chain on every tick (observed fleet-wide at up to ~850
+ * `git:status` IPC calls per second). A throttle guarantees at most one emit per window and
+ * always settles.
+ */
+const REPO_CHANGE_THROTTLE_MS = 5_000
+
+/**
+ * Path segments whose churn says nothing about git state the UI shows. `.git/objects` (and
+ * pack files under it) is written on every fetch/gc without changing status output;
+ * `node_modules` is the classic build-noise firehose.
+ */
+const REPO_NOISE_SEGMENT = /(^|[\\/])(node_modules|\.git[\\/]objects)([\\/]|$)/
+
 function closeWatchEntry(filePath: string, entry: FileWatchEntry): void {
   if (entry.debounceTimer) clearTimeout(entry.debounceTimer)
   entry.watcher.close()
@@ -118,7 +135,7 @@ export function stopAllFileWatches(): void {
   }
 }
 
-export function startRepoGitWatch(win: BrowserWindow, repoPath: string, onChanged?: (repoPath: string) => void): boolean {
+export function startRepoGitWatch(win: BrowserWindow, repoPath: string): boolean {
   const existing = repoWatchers.get(repoPath)
   if (existing) {
     existing.refCount += 1
@@ -128,24 +145,28 @@ export function startRepoGitWatch(win: BrowserWindow, repoPath: string, onChange
   if (!existsSync(repoPath)) return false
 
   try {
-    const watcher = watch(repoPath, { recursive: true }, () => {
+    // Trailing throttle, not a debounce: the first change schedules one emit and later
+    // changes inside the window collapse into it. Freshness of the *data* behind the emit is
+    // the job of the git read cache's TTL (git.ts), which this watcher deliberately no longer
+    // invalidates — see the `git:watchStart` handler.
+    const watcher = watch(repoPath, { recursive: true }, (_eventType, changedName) => {
+      if (typeof changedName === 'string' && REPO_NOISE_SEGMENT.test(changedName)) return
+
       const current = repoWatchers.get(repoPath)
-      if (!current) return
-      if (current.debounceTimer) clearTimeout(current.debounceTimer)
+      if (!current || current.debounceTimer) return
 
       current.debounceTimer = setTimeout(() => {
         const latest = repoWatchers.get(repoPath)
         if (!latest) return
         latest.debounceTimer = null
 
-        onChanged?.(repoPath)
         if (!win.isDestroyed()) {
           emitAppEvent(win, 'git:repoChanged', {
             path: repoPath,
             changedAt: Date.now(),
           })
         }
-      }, 1000)
+      }, REPO_CHANGE_THROTTLE_MS)
     })
 
     repoWatchers.set(repoPath, { watcher, refCount: 1, debounceTimer: null })

--- a/apps/desktop/src/main/ipc/channel-handlers.ts
+++ b/apps/desktop/src/main/ipc/channel-handlers.ts
@@ -1215,10 +1215,13 @@ export const channelHandlers = {
   },
 
   /**
-   * `invalidateRepoGitCache` is passed as a *reference*, not a call: the watcher fires it
-   * every time it sees the repo change. Calling it here instead would invalidate once,
-   * immediately, and hand the watcher `undefined` — a mistake the recorded call log alone
-   * cannot see, so the characterisation test pins the callback's identity.
+   * The watcher used to receive `invalidateRepoGitCache` as a callback and fire it on every
+   * filesystem change it saw. During an active agent run the worktree changes continuously,
+   * so the git read cache's 5s status TTL (git.ts CACHE_POLICY) was wiped before it could
+   * ever serve a hit — every renderer refresh tick became a fresh `git status --porcelain` +
+   * `git diff --numstat`. The callback is gone: mutations invalidate their own scope inside
+   * `git.ts`, external changes are bounded by the TTL, and the watcher's only job is to tell
+   * the renderer *that* something changed (now throttled inside `startRepoGitWatch`).
    *
    * `ctx.window` is the watcher's event target, the same shape as `files:watchStart`: the IPC
    * path closed over the window `registerIpcHandlers` was given and the control-RPC path took
@@ -1227,8 +1230,7 @@ export const channelHandlers = {
    * Note what is absent: no `getConfigForPath`. The repo watcher is `fs.watch` underneath and
    * is keyed on the path alone — a remotely-hosted repo simply reports "not watching".
    */
-  'git:watchStart': (ctx, repoPath) =>
-    startRepoGitWatch(ctx.window, repoPath, invalidateRepoGitCache),
+  'git:watchStart': (ctx, repoPath) => startRepoGitWatch(ctx.window, repoPath),
 
   // Passing the `: void` callee's value through, per the rule above. Both pre-fold paths
   // discarded it — control-rpc.ts called it as a statement and followed it with

--- a/apps/desktop/src/main/ipc/thread-context.ts
+++ b/apps/desktop/src/main/ipc/thread-context.ts
@@ -86,12 +86,13 @@ export function getConfigForPath(path: string): { ssh: SshConfig | null; wsl: Ws
  * Invalidate a repo's git cache when all you have is its path.
  *
  * It used to be the trailing line of 24 `git:*` handlers; every `git.ts` mutation now
- * invalidates its own scope, so three consumers are left, and all three genuinely lack the
+ * invalidates its own scope, so two consumers are left, and both genuinely lack the
  * `ssh`/`wsl` pair that this function's `getLocationByPath` recovers:
  *
- * - `git:watchStart` passes it as a **callback** to `startRepoGitWatch`. The watcher fires it
- *   on every filesystem change it sees, from outside any git operation, so there is no call
- *   site that could hold a host config. This is the reason the helper still exists.
+ * (The repo watcher used to be the third — `git:watchStart` passed this as a callback fired
+ * on every filesystem change. That wiped the status TTL continuously during agent runs and
+ * is gone; external changes are now bounded by the TTL alone.)
+ *
  * - `forge:pr:checkout` — the mutation is a forge adapter method, not a `git.ts` function.
  * - `git:publishBranch`'s `finally` — a composite whose steps each self-invalidate; see the
  *   note on that handler for why the belt-and-braces call is kept.


### PR DESCRIPTION
Part of #54, first slice of #55.

## Problem (from the Grafana audit)

- 75M+ IPC calls each of `git:status` / `git:isRepo` / `git:head` in 14 days; fleet `git:status` rate peaked ~850/s for a handful of installs.
- `git:status` p50 494ms; `git:head` p50 101ms for what is a ~10ms `rev-parse`.
- Logs show the same repo refreshed every ~2s for the entire duration of any agent run.

## Changes

1. **`file-watch.ts`** — the repo watcher used a resettable 1s debounce; continuous worktree writes during a run meant it fired every ~1.75s indefinitely. Now a 5s trailing throttle (first change schedules one emit; later changes collapse into it), and events under `node_modules` / `.git/objects` are ignored.
2. **`channel-handlers.ts` (`git:watchStart`)** — no longer passes `invalidateRepoGitCache` as the watcher callback. That callback wiped the 5s status TTL (`git.ts` CACHE_POLICY) on every filesystem change, making every refresh tick a real `git status --porcelain` + `git diff --numstat`. Mutations already self-invalidate inside `git.ts`; external changes are now bounded by the TTL.
3. **`driver/runner/local.ts`** — on Windows, `git` and explicit `.exe` binaries spawn directly (`shell: false`, `windowsHide: true`) instead of through cmd.exe. `shell: true` remains only for npm-style `.cmd` wrappers, which are the reason it existed.

Characterisation test updated: the absence of the watcher invalidation callback is now the pinned behaviour.

## Behaviour notes

- `git:repoChanged` latency rises from ~1s to ≤5s after an isolated change; status data freshness is bounded by the existing 5s TTL either way.
- Direct git spawn passes args verbatim (no `winQuote` hand-quoting) — this also removes a quoting/injection hazard on branch-name-controlled args.

## Verification

- `vitest run` on dispatch-characterisation, runners, runner-run, git-cache-invalidation: 381 passed.
- `tsc --build --noEmit` clean.

## Success metric (watch after merge)

`sum(rate(polycode_ipc_calls_total{channel="git:status"}[10m]))` should drop from hundreds/s to low tens/s; `git:head` p50 should roughly halve. We'll gather ~a week of data before the next slice (porcelain=v2 coalescing, compareToMain dedup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)