### PR TITLE
perf: O(n) foldMessages, no mid-stream transcript reloads, async pathExists

### DIFF
--- a/apps/desktop/src/main/__tests__/dispatch-characterisation.test.ts
+++ b/apps/desktop/src/main/__tests__/dispatch-characterisation.test.ts
@@ -306,6 +306,18 @@ const H = vi.hoisted(() => {
   }
 })
 
+// `locations:pathExists` is async (`fs/promises.access`) so a slow or network path never
+// blocks the main process; it answers from the same `pathExists` switch as `existsSync`.
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs/promises')>()
+  return {
+    ...actual,
+    access: async () => {
+      if (!H.state.pathExists) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    },
+  }
+})
+
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>()
   return {

--- a/apps/desktop/src/main/ipc/channel-handlers.ts
+++ b/apps/desktop/src/main/ipc/channel-handlers.ts
@@ -61,6 +61,7 @@
 import { spawn } from 'child_process'
 import { randomBytes } from 'crypto'
 import { existsSync, readFileSync } from 'fs'
+import { access } from 'fs/promises'
 import { basename, join } from 'path'
 import { pathToFileURL } from 'url'
 import { app, clipboard, dialog, shell } from 'electron'
@@ -606,7 +607,9 @@ export const channelHandlers = {
 
   'locations:list': (_ctx, projectId) => listSyncedLocations(projectId),
 
-  'locations:pathExists': (_ctx, path) => existsSync(path),
+  // Async on purpose: the renderer sweeps this across every visible location, and a sync
+  // stat on a slow/network path blocks every other IPC handler behind it.
+  'locations:pathExists': (_ctx, path) => access(path).then(() => true, () => false),
 
   // The optional pool/ssh/wsl arguments are passed through raw: db/queries.ts coalesces
   // every one of them before binding, so a `?? null` here would only be duplication.

--- a/apps/desktop/src/renderer/src/hooks/__tests__/useDatabaseSync.test.tsx
+++ b/apps/desktop/src/renderer/src/hooks/__tests__/useDatabaseSync.test.tsx
@@ -39,5 +39,19 @@ describe('useDatabaseSync', () => {
       expect(invoke).toHaveBeenCalledWith('messages:listBySession', 'session-1')
     })
   })
+
+  it('does not reload the transcript of a running thread — the stream and thread:complete own it', async () => {
+    useThreadStore.setState({ statusMap: { 'thread-1': 'running' } })
+    renderHook(() => useDatabaseSync())
+    invoke.mockClear()
+
+    act(() => window.dispatchEvent(new Event('focus')))
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('threads:list', 'project-1')
+    })
+    expect(invoke).not.toHaveBeenCalledWith('sessions:list', 'thread-1')
+    expect(invoke).not.toHaveBeenCalledWith('messages:listBySession', 'session-1')
+  })
 })
 // @vitest-environment happy-dom

--- a/apps/desktop/src/renderer/src/hooks/useDatabaseSync.ts
+++ b/apps/desktop/src/renderer/src/hooks/useDatabaseSync.ts
@@ -66,6 +66,13 @@ export function useDatabaseSync(): void {
         const threadId = latestThreadState.selectedThreadId
         if (!threadId || threadId.startsWith('pending-thread-')) return
 
+        // A running Turn is already streaming into the transcript over push events, and
+        // `thread:complete` reconciles it against the database when the Turn ends. Reloading
+        // the whole transcript mid-stream is pure cost: on a large Thread it blocks the main
+        // process for seconds (Grafana: p99 4.4s) right while chunks are arriving, which the
+        // user sees as words trickling in and a frozen composer.
+        if (latestThreadState.statusMap[threadId] === 'running') return
+
         await useSessionStore.getState().fetch(threadId).catch(() => undefined)
         const sessionId = useSessionStore.getState().activeSessionByThread[threadId]
         if (sessionId) {

--- a/apps/desktop/src/renderer/src/stores/messages.ts
+++ b/apps/desktop/src/renderer/src/stores/messages.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { eventRole, foldMessages } from '@polycode/shared'
+import { appendFoldedMessage, eventRole } from '@polycode/shared'
 import { Message, OutputEvent } from '../types/ipc'
 import { isRemoteTransportError } from '../lib/remoteErrors'
 
@@ -77,7 +77,7 @@ export const useMessageStore = create<MessageStore>((set) => ({
     set((s) => ({
       messagesByThread: {
         ...s.messagesByThread,
-        [threadId]: foldMessages([...(s.messagesByThread[threadId] ?? []), msg])
+        [threadId]: appendFoldedMessage(s.messagesByThread[threadId] ?? [], msg)
       }
     }))
   },
@@ -98,7 +98,7 @@ export const useMessageStore = create<MessageStore>((set) => ({
     set((s) => ({
       messagesBySession: {
         ...s.messagesBySession,
-        [sessionId]: foldMessages([...(s.messagesBySession[sessionId] ?? []), msg])
+        [sessionId]: appendFoldedMessage(s.messagesBySession[sessionId] ?? [], msg)
       }
     }))
   },

--- a/apps/mobile/src/stores/messages.ts
+++ b/apps/mobile/src/stores/messages.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import {
   eventRole,
-  foldMessages,
+  appendFoldedMessage,
   type Message,
   type OutputEvent,
   type RateLimitInfo,
@@ -134,7 +134,7 @@ export const useMessagesStore = create<MessagesState>((set) => ({
     set((s) => ({
       messagesByThread: {
         ...s.messagesByThread,
-        [threadId]: foldMessages([...(s.messagesByThread[threadId] ?? []), msg]),
+        [threadId]: appendFoldedMessage(s.messagesByThread[threadId] ?? [], msg),
       },
     }))
   },

--- a/packages/shared/src/__tests__/fold-messages.test.ts
+++ b/packages/shared/src/__tests__/fold-messages.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { appendFoldedMessage, foldMessages, parseMetadata, type Message } from '../index'
+
+/**
+ * `foldMessages` is now an O(n) in-place fold with a cached tail metadata. These tests pin it
+ * against a deliberately naive reference (re-fold the whole prefix on every append) across
+ * randomised streams that exercise every merge rule: same/different scope, text/thinking/
+ * tool_result, authoritative snapshots, user-role echoes, Codex summary parts, and the legacy
+ * Codex marker. Any divergence between the fast path and the reference is a semantic change.
+ */
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function randomStream(seed: number, length: number): Message[] {
+  const rand = mulberry32(seed)
+  const pick = <T,>(items: T[]): T => items[Math.floor(rand() * items.length)]
+  const messages: Message[] = []
+  for (let i = 0; i < length; i++) {
+    const role = pick(['assistant', 'assistant', 'assistant', 'user', 'system'] as const)
+    const type = pick([undefined, 'text', 'text', 'thinking', 'thinking', 'tool_result', 'tool_result', 'tool_call'])
+    const scope = pick([{}, {}, { agent_task_id: 'agent-a' }, { agent_parent_tool_use_id: 'tool-p' }])
+    const metadata: Record<string, unknown> = { ...scope }
+    if (type) metadata.type = type
+    if (type === 'tool_result') {
+      metadata.tool_use_id = pick(['tu-1', 'tu-1', 'tu-2'])
+      if (rand() < 0.2) metadata.authoritative = true
+    }
+    if (type === 'thinking') {
+      if (rand() < 0.4) {
+        metadata.source = 'codex_reasoning_summary'
+        metadata.item_id = pick(['item-1', 'item-2'])
+        metadata.summary_index = pick([0, 1])
+      } else if (rand() < 0.2) {
+        metadata.source = 'claude_task'
+      }
+    }
+    if (rand() < 0.1) metadata.role = pick(['user', 'assistant'])
+    const legacyMarker = type === 'thinking' && metadata.source === 'codex_reasoning_summary' && rand() < 0.15
+    messages.push({
+      id: `m${i}`,
+      thread_id: 't',
+      session_id: 's',
+      role,
+      content: legacyMarker ? 'Reasoning summary updated.' : (rand() < 0.3 ? `chunk${i} ` : `chunk${i - 1} chunk${i} `),
+      metadata: rand() < 0.1 ? null : JSON.stringify(metadata),
+      created_at: `2026-01-01T00:00:${String(i % 60).padStart(2, '0')}.${String(i).padStart(3, '0')}Z`,
+    })
+  }
+  return messages
+}
+
+/** Reference: fold the whole prefix from scratch on every append. Trivially correct, O(n²). */
+function referenceFold(messages: Message[]): Message[] {
+  let folded: Message[] = []
+  for (let i = 0; i < messages.length; i++) folded = foldMessages(messages.slice(0, i + 1))
+  return folded
+}
+
+describe('foldMessages (O(n) fold)', () => {
+  it('matches the whole-prefix reference on randomised streams', () => {
+    for (let seed = 1; seed <= 40; seed++) {
+      const stream = randomStream(seed, 60)
+      expect(foldMessages(stream)).toEqual(referenceFold(stream))
+    }
+  })
+
+  it('appendFoldedMessage on a folded transcript equals folding the whole stream', () => {
+    for (let seed = 100; seed <= 140; seed++) {
+      const stream = randomStream(seed, 80)
+      let folded: Message[] = []
+      for (const message of stream) {
+        const next = appendFoldedMessage(folded, message)
+        expect(next).not.toBe(folded)
+        folded = next
+      }
+      expect(folded).toEqual(foldMessages(stream))
+    }
+  })
+
+  it('appendFoldedMessage does not mutate its input', () => {
+    const stream = randomStream(7, 30)
+    const folded = foldMessages(stream)
+    const snapshot = JSON.stringify(folded)
+    appendFoldedMessage(folded, { ...stream[3], id: 'extra', content: 'more' })
+    expect(JSON.stringify(folded)).toBe(snapshot)
+  })
+
+  it('caches the tail metadata consistently with what the merged message carries', () => {
+    // A merged tool_result adopts the incoming metadata; a merged text keeps the previous.
+    // If the cache and the message ever disagreed, the *next* append would branch wrongly.
+    const stream = randomStream(11, 200)
+    const folded = foldMessages(stream)
+    for (const message of folded) {
+      expect(parseMetadata(message.metadata)).toEqual(parseMetadata(message.metadata))
+    }
+    const tail = folded[folded.length - 1]
+    const appended = appendFoldedMessage(folded, { ...tail, id: 'tail-2', content: 'x' })
+    expect(appended).toEqual(foldMessages([...stream, { ...tail, id: 'tail-2', content: 'x' }]))
+  })
+
+  it('stays linear: 50k messages fold well under a second', () => {
+    const stream = randomStream(3, 50_000)
+    const started = performance.now()
+    const folded = foldMessages(stream)
+    expect(folded.length).toBeGreaterThan(0)
+    // The previous implementation took ~10s here (28s on a real 74k-row session).
+    expect(performance.now() - started).toBeLessThan(1_000)
+  })
+})

--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -47,12 +47,36 @@ export function eventRole(event: OutputEvent): Message['role'] {
 }
 
 /**
- * Append a streamed message to a list, merging consecutive same-scope
+ * Fold accumulator. `tailMetadata` caches the parsed metadata of the last message so a
+ * long run of appends never re-parses the tail's JSON on every step.
+ */
+interface FoldState {
+  messages: Message[]
+  tailMetadata: Record<string, unknown> | null
+}
+
+function replaceTail(state: FoldState, message: Message, metadata: Record<string, unknown> | null): void {
+  state.messages[state.messages.length - 1] = message
+  state.tailMetadata = metadata
+}
+
+function pushTail(state: FoldState, message: Message, metadata: Record<string, unknown> | null): void {
+  state.messages.push(message)
+  state.tailMetadata = metadata
+}
+
+/**
+ * Append a streamed message to the accumulator, merging consecutive same-scope
  * text/thinking chunks and same-tool_use_id tool_result chunks into the
  * previous bubble. This encodes the streaming display rules shared by the
  * desktop renderer and the mobile app.
+ *
+ * Mutates `state` in place. The previous implementation rebuilt the array on
+ * every step (`[...messages, incoming]`), which made folding O(n²): a real 74k-row
+ * session took 28s to fold on the Electron main thread (the SQLite read took 0.3s),
+ * and the renderer re-folded the whole transcript on every streamed chunk.
  */
-function appendOrMergeMessage(messages: Message[], incoming: Message): Message[] {
+function appendOrMergeMessage(state: FoldState, incoming: Message): void {
   const nextMetadata = parseMetadata(incoming.metadata)
   const incomingType = nextMetadata?.type
 
@@ -64,15 +88,17 @@ function appendOrMergeMessage(messages: Message[], incoming: Message): Message[]
     incoming.content === LEGACY_CODEX_REASONING_SUMMARY_MARKER &&
     isCodexReasoningSummary(nextMetadata)
   ) {
-    return messages
+    return
   }
 
+  const { messages } = state
   const previous = messages[messages.length - 1]
   if (!previous || previous.role !== incoming.role) {
-    return [...messages, incoming]
+    pushTail(state, incoming, nextMetadata)
+    return
   }
 
-  const previousMetadata = parseMetadata(previous.metadata)
+  const previousMetadata = state.tailMetadata
 
   // Never merge across agent scopes: main-scope assistant text followed by
   // sub-agent assistant text (both role 'assistant') must stay separate bubbles.
@@ -83,20 +109,24 @@ function appendOrMergeMessage(messages: Message[], incoming: Message): Message[]
     // messages, never streaming chunks — don't merge them into the previous
     // bubble or fuse consecutive user messages together.
     if (nextMetadata?.role === 'user' || previousMetadata?.role === 'user') {
-      return [...messages, incoming]
+      pushTail(state, incoming, nextMetadata)
+      return
     }
     const previousType = previousMetadata?.type
     if ((!previousType || previousType === 'text') && sameScope) {
-      return [
-        ...messages.slice(0, -1),
+      replaceTail(
+        state,
         {
           ...previous,
           content: previous.content + incoming.content,
           created_at: incoming.created_at,
         },
-      ]
+        previousMetadata,
+      )
+      return
     }
-    return [...messages, incoming]
+    pushTail(state, incoming, nextMetadata)
+    return
   }
 
   if (incomingType === 'thinking') {
@@ -114,8 +144,8 @@ function appendOrMergeMessage(messages: Message[], incoming: Message): Message[]
         isCodexSummaryPair && !isSameCodexReasoningSummaryPart(previousMetadata, nextMetadata)
           ? '\n\n'
           : ''
-      return [
-        ...messages.slice(0, -1),
+      replaceTail(
+        state,
         {
           ...previous,
           content: previous.content + separator + incoming.content,
@@ -124,9 +154,12 @@ function appendOrMergeMessage(messages: Message[], incoming: Message): Message[]
           metadata: isCodexSummaryPair ? incoming.metadata : previous.metadata,
           created_at: incoming.created_at,
         },
-      ]
+        isCodexSummaryPair ? nextMetadata : previousMetadata,
+      )
+      return
     }
-    return [...messages, incoming]
+    pushTail(state, incoming, nextMetadata)
+    return
   }
 
   if (incomingType === 'tool_result') {
@@ -139,14 +172,13 @@ function appendOrMergeMessage(messages: Message[], incoming: Message): Message[]
     const previousToolUseId = typeof previousMetadata?.tool_use_id === 'string' ? previousMetadata.tool_use_id : null
     const nextToolUseId = typeof nextMetadata?.tool_use_id === 'string' ? nextMetadata.tool_use_id : null
     if (!previousIsToolResult || !previousToolUseId || !nextToolUseId || previousToolUseId !== nextToolUseId) {
-      return [...messages, incoming]
+      pushTail(state, incoming, nextMetadata)
+      return
     }
 
     if (nextMetadata?.authoritative === true) {
-      return [
-        ...messages.slice(0, -1),
-        { ...incoming, id: previous.id },
-      ]
+      replaceTail(state, { ...incoming, id: previous.id }, nextMetadata)
+      return
     }
 
     const previousContent = previous.content
@@ -155,24 +187,42 @@ function appendOrMergeMessage(messages: Message[], incoming: Message): Message[]
         ? incoming.content
         : previousContent + incoming.content
 
-    return [
-      ...messages.slice(0, -1),
+    replaceTail(
+      state,
       {
         ...previous,
         content: nextContent,
         metadata: incoming.metadata,
         created_at: incoming.created_at,
       },
-    ]
+      nextMetadata,
+    )
+    return
   }
 
-  return [...messages, incoming]
+  pushTail(state, incoming, nextMetadata)
 }
 
 /**
  * Fold persisted or streamed messages into their display form using the same
- * merge rules in every caller.
+ * merge rules in every caller. O(n); returns a new array.
  */
 export function foldMessages(messages: Message[]): Message[] {
-  return messages.reduce<Message[]>(appendOrMergeMessage, [])
+  const state: FoldState = { messages: [], tailMetadata: null }
+  for (const message of messages) appendOrMergeMessage(state, message)
+  return state.messages
+}
+
+/**
+ * Append one streamed message to an already-folded transcript, returning a new
+ * array (the input is not mutated, so it is safe for immutable stores). O(n) in
+ * the pointer copy only — it never re-folds the prefix, which is what made every
+ * streamed chunk O(n²) before.
+ */
+export function appendFoldedMessage(folded: Message[], incoming: Message): Message[] {
+  const messages = folded.slice()
+  const tail = messages[messages.length - 1]
+  const state: FoldState = { messages, tailMetadata: tail ? parseMetadata(tail.metadata) : null }
+  appendOrMergeMessage(state, incoming)
+  return state.messages
 }


### PR DESCRIPTION
Part of #54, first slice of #56.

## Problem (from the Grafana audit)

- `messages:listBySession` p95 ≈ 1s, p99 **4.4s**, max 10.4s, correlated 1:1 with main-process event-loop stalls (e.g. 2026-09-03 21:45:50Z: `main-thread stall 7280ms` at the exact completion of an 8.0s `listBySession`). Every other IPC — including the composer's — queues behind it.
- 53% of those calls were re-fetches of the same session within 30s.
- Streaming on long threads: words trickle in, composer freezes.

## Root cause, measured

On a real 74,571-row session from a local database:

| step | before | after |
|---|---|---|
| SQLite read | 342ms | 342ms |
| `foldMessages` | **28,323ms** | **680ms** |

`foldMessages` rebuilt the array on every step (`[...messages, incoming]` / `[...messages.slice(0,-1), merged]`) and re-parsed the tail's metadata JSON each time — O(n²). The renderer store then re-folded the *entire* transcript on every streamed chunk, and `groupByAgent` folded again per render.

## Changes

1. **`packages/shared/src/messages.ts`** — `foldMessages` is now an in-place accumulator with a cached parsed tail. Same merge rules, same branches; output verified **byte-identical** against the old implementation across all 74,571 real rows. New `appendFoldedMessage(folded, incoming)` appends one message to an already-folded transcript without re-folding the prefix (returns a new array; safe for immutable stores).
2. **Desktop + mobile message stores** — streamed chunks use `appendFoldedMessage` instead of re-folding the whole transcript.
3. **`useDatabaseSync`** — skips the 30s transcript reload while the selected thread is `running`. The stream owns the transcript during a Turn and `thread:complete` reconciles it against the database.
4. **`locations:pathExists`** — `fs/promises.access` instead of `existsSync` (the renderer sweeps this across every visible location).

## Tests

- `packages/shared/src/__tests__/fold-messages.test.ts`: property test pinning the O(n) fold against a whole-prefix reference across 40 randomised streams that exercise every merge rule (scope changes, text/thinking/tool_result, authoritative snapshots, user-role echoes, Codex summary parts, legacy marker); `appendFoldedMessage` ≡ `foldMessages` of the whole stream; non-mutation; a 50k-message linearity guard (<1s; was ~10s).
- `useDatabaseSync`: new case for the running-thread skip.
- Characterisation test: `fs/promises.access` mocked alongside `existsSync`.
- Existing message-compaction, groupByAgent, message-store tests unchanged and passing. `tsc` clean for desktop and mobile.

## Not in this PR (remaining #56 follow-ups)

- Paging/tailing the transcript so the initial load and `thread:complete` reconciliation don't ship the full session (83MB serialised for the session above).
- Replacing the `thread:complete` full refetch with by-ID reconciliation.

## Success metric

`histogram_quantile(0.99, sum by (le) (rate(polycode_ipc_duration_milliseconds_bucket{channel="messages:listBySession"}[1h])))` should fall from ~4.4s to well under 1s; `polycode_event_loop_stall_milliseconds` (main) count >1s should drop sharply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)